### PR TITLE
Added connection status error handling.

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -25,6 +25,7 @@ format_variables_acs <- function(variables) {
 load_data_acs <- function(geography, formatted_variables, key, endyear, state = NULL, county = NULL, survey) {
 
   if (survey == "acs1") {
+    if (endyear <= 2010) print("The acs1 data is currently available beginning in 2011. Please select a different year.")
     if (endyear > 2014) {
       survey <- "acs/acs1"
     }
@@ -98,9 +99,13 @@ load_data_acs <- function(geography, formatted_variables, key, endyear, state = 
                                    key = key))
   }
 
-
-
-  content <- content(call, as = "text")
+  # Make sure call status returns 200, else, print the error message for the user.
+  callStatus <- http_status(call)
+  if (callStatus$reason != "OK") {
+    print(paste0(callStatus$category, " ", callStatus$reason, " ", callStatus$message))
+  } else {
+    content <- content(call, as = "text")
+  }
 
   validate_call(content = content, geography = geography, year = endyear,
                 dataset = survey)
@@ -201,9 +206,13 @@ load_data_decennial <- function(geography, variables, key, year,
                                    key = key))
   }
 
-
-
-  content <- content(call, as = "text")
+  # Make sure call status returns 200, else, print the error message for the user.
+  callStatus <- http_status(call)
+  if (callStatus$reason != "OK") {
+    print(paste0(callStatus$category, " ", callStatus$reason, " ", callStatus$message))
+  } else {
+    content <- content(call, as = "text")
+  }
 
   # Fix issue in SF3 2000 API - https://github.com/walkerke/tidycensus/issues/22
   if (year == 2000 & sumfile == "sf3") {


### PR DESCRIPTION
@walkerke this issue https://github.com/walkerke/tidycensus/issues/28#issuecomment-335118268 got me thinking. The `httr` package, which is already imported, has a neat function called `http_status()`, which returns the connection status of a call. In one of the user-examples in the issue, the user attempts to query data that aren't available, with this addition the user would receive the specific error message for the connection. The different types of error types for can be found [here](https://github.com/walkerke/tidycensus/issues/28#issuecomment-335118268) starting on line 66.

So, the user-error of:

```
income <- get_acs(geography = "place", variables = "B19013_001", survey = "acs1", endyear = 2010, key = Sys.getenv("CENSUS_API_KEY"))
```

...would return:

```
The one-year ACS provides data for geographies with populations of 65,000 and greater.
[1] "The acs1 data is currently available beginning in 2011. Please select a different year."
[1] "Client error Not Found Client error: (404) Not Found"
```

Valid calls return as they always have. I figured this would be a nice addition, not only for end-users, but also to be used for diagnostic purposes in-development.

The code looks like this, and was added to the `laod_data_acs()` and `load_data_decennial()` functions.

```
  # Make sure call status returns 200, else, print the error message for the user.
  callStatus <- http_status(call)
  if (callStatus$reason != "OK") {
    print(paste0(callStatus$category, " ", callStatus$reason, " ", callStatus$message))
  } else {
    content <- content(call, as = "text")
  }
```