### PR TITLE
don't change working directory when saving API key

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -131,7 +131,8 @@ use_tigris <- function(geography, year, cb = TRUE, resolution = "500k",
 census_api_key <- function(key, overwrite = FALSE, install = FALSE){
 
   if (install == TRUE) {
-    setwd(Sys.getenv("HOME"))
+    old_wd <- setwd(Sys.getenv("HOME"))
+    on.exit(setwd(old_wd))
     if(file.exists(".Renviron")){
       # Backup original .Renviron before doing anything else here.
       file.copy(".Renviron", ".Renviron_backup")


### PR DESCRIPTION
Hello,

Thank you for the great package! I started to use it yesterday for the first time. I noticed that it changed my working directory after I saved an API key using the .Renviron helper. Taking a closer look, this doesn't seem like it's necessary and this small PR should change that behavior.

Thanks again!