### PR TITLE
Convert new missing values in 2016 5-year to NA

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -252,8 +252,8 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
       spread(type, value) %>%
       mutate(moe = moe * moe_factor)
 
-    # Convert -555555555 values to NA (ACS1 issue)
-    dat2[dat2 == -555555555] <- NA
+    # Convert -555555555, -666666666, or -222222222 values to NA
+    dat2[dat2 == -555555555 | dat2 == -666666666 | dat2 == -222222222] <- NA
 
 
   } else if (output == "wide") {
@@ -262,8 +262,8 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
     dat <- dat[!duplicated(names(dat), fromLast = TRUE)]
 
-    # Convert -555555555 values to NA (ACS1 issue)
-    dat[dat == -555555555] <- NA
+    # Convert -555555555, -666666666, or -222222222 values to NA
+    dat[dat == -555555555 | dat == -666666666 | dat == -222222222] <- NA
 
     # Find MOE vars
     # moe_vars <- grep("*M", names(dat))
@@ -295,8 +295,9 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
       select(-NAME.y) %>%
       mutate(summary_moe = round(summary_moe * moe_factor, 0))
 
-    # Convert -555555555 values to NA (ACS1 issue)
-    dat2[dat2 == -555555555] <- NA
+    # Convert -555555555, -666666666, or -222222222 values to NA
+    dat2[dat2 == -555555555 | dat2 == -666666666 | dat2 == -222222222] <- NA
+
 
   }
 


### PR DESCRIPTION
This is my first ever PR, so I'm not totally sure I'm doing it right. But here we go:

Found a bug when downloading new 2016 5-year estimates where some missing estimates return `-666666666` and missing MOE return `-222222222`. See below for example:

``` r
library(tidycensus)
library(dplyr)

get_acs(
  state = "GA",
  county = "Fulton",
  geography = "block group",
  variables = "B01002_001",
  survey = "acs5",
  year = 2016,
  geometry = FALSE,
) %>%
  filter(GEOID == "131219800001") %>% # select bg with NA value
  select(-NAME) # for nice printing
#> # A tibble: 1 x 4
#>          GEOID   variable   estimate        moe
#>          <chr>      <chr>      <dbl>      <dbl>
#> 1 131219800001 B01002_001 -666666666 -222222222
```

To deal with this, I simply changed the values in the `get_acs()` to replace `-666666666` and `-222222222` with `NA`. The updated function returns what I believe to be correct results:

``` r
library(tidycensus)
library(dplyr)

get_acs(
  state = "GA",
  county = "Fulton",
  geography = "block group",
  variables = "B01002_001",
  survey = "acs5",
  year = 2016,
  geometry = FALSE,
) %>%
  filter(GEOID == "131219800001") %>% # select bg with NA value
  select(-NAME) # for nice printing
#> # A tibble: 1 x 4
#>          GEOID   variable   estimate        moe
#>          <chr>      <chr>      <dbl>      <dbl>
#> 1 131219800001 B01002_001        NA          NA
```
Hope this helps!