### PR TITLE
fix api call for acs1 subject tables

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -154,6 +154,11 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
   if (geography == "zcta") geography <- "zip code tabulation area"
 
+  if (geography == "zip code tabulation area" && (!is.null(state) || !is.null(county))) {
+    stop("ZCTAs can only be requested for the entire country, not within states or counties.",
+         call. = FALSE)
+  }
+
   # Allow users to get all block groups in a state
 
   if ((geography == "block group" && is.null(county)) || (geography == "tract" && is.null(county) && year < 2015)) {

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -134,15 +134,7 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
 
   if (grepl("^S[0-9].", formatted_variables)) {
     message("Using the ACS Subject Tables")
-    if (survey == "acs1") {
-      base <- paste("https://api.census.gov/data",
-                    as.character(year),
-                    "subject",
-                    sep = "/")
-    } else {
-      base <- paste0(base, "/subject")
-
-    }
+    base <- paste0(base, "/subject")
   }
 
   for_area <- paste0(geography, ":*")


### PR DESCRIPTION
In tidycensus 0.8.1 when trying to access ACS 1-year Subject tables, the call to the API fails:

``` r
get_acs(
  geography = "state",
  variables = "S2001_C01_002E",
  survey = "acs1"
  )
#> Getting data from the 2016 1-year ACS
#> The one-year ACS provides data for geographies with populations of 65,000 and greater.
#> Using the ACS Subject Tables
#> Error: One or more of your requested variables is likely not available at the requested geography.  Please refine your selection.
```
Calling the 5-year Subject tables works as expected:

``` r
get_acs(
  geography = "state",
  variables = "S2001_C01_002E",
  survey = "acs5"
  )
#> Getting data from the 2012-2016 5-year ACS
#> Using the ACS Subject Tables
#> # A tibble: 52 x 5
#>    GEOID NAME                 variable      estimate   moe
#>    <chr> <chr>                <chr>            <dbl> <dbl>
#>  1 01    Alabama              S2001_C01_002    27882   284
#>  2 02    Alaska               S2001_C01_002    36691   356
#>  3 04    Arizona              S2001_C01_002    30096    98
#>  4 05    Arkansas             S2001_C01_002    26856   136
#>  5 06    California           S2001_C01_002    31736    54
#>  6 08    Colorado             S2001_C01_002    33253   252
#>  7 09    Connecticut          S2001_C01_002    39198   375
#>  8 10    Delaware             S2001_C01_002    33774   652
#>  9 11    District of Columbia S2001_C01_002    48059   900
#> 10 12    Florida              S2001_C01_002    28148   141
#> # … with 42 more rows
```

This PR fixes the API URL call for 1-year Subject tables (to the same as the 5-year URL base) and appears to be working on my end:
``` r
get_acs(
  geography = "state",
  variables = "S2001_C01_002E",
  survey = "acs1"
  )
#> Getting data from the 2016 1-year ACS
#> The one-year ACS provides data for geographies with populations of 65,000 and greater.
#> Using the ACS Subject Tables
#> # A tibble: 52 x 5
#>   GEOID NAME                 variable      estimate   moe
#>   <chr> <chr>                <chr>            <dbl> <dbl>
#> 1 01    Alabama              S2001_C01_002    29164   651
#> 2 02    Alaska               S2001_C01_002    36209   684
#> 3 04    Arizona              S2001_C01_002    30675   201
#> 4 05    Arkansas             S2001_C01_002    27687   624
#> 5 06    California           S2001_C01_002    32499   285
#> 6 08    Colorado             S2001_C01_002    35274   231
#> 7 09    Connecticut          S2001_C01_002    40323   363
#> 8 10    Delaware             S2001_C01_002    35408   698
#> 9 11    District of Columbia S2001_C01_002    50364  1289
#>10 12    Florida              S2001_C01_002    29550   349
# … with 42 more rows
```