### PR TITLE
fix check name errors introduced with tibble 1.5

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -236,9 +236,11 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
     stop("You have supplied an invalid or inactive API key. To obtain a valid API key, visit https://api.census.gov/data/key_signup.html. To activate your key, be sure to click the link provided to you in the email from the Census Bureau that contained your key.", call. = FALSE)
   }
 
-  dat <- as_tibble(fromJSON(content), .name_repair = "minimal")
+  dat <- fromJSON(content)
 
   colnames(dat) <- dat[1,]
+
+  dat <- as_tibble(dat)
 
   dat <- dat[-1,]
 
@@ -393,9 +395,11 @@ load_data_decennial <- function(geography, variables, key, year,
 
   }
 
-  dat <- as_tibble(fromJSON(content), .name_repair = "minimal")
+  dat <- fromJSON(content)
 
   colnames(dat) <- dat[1,]
+
+  dat <- as_tibble(dat)
 
   dat <- dat[-1,]
 
@@ -567,9 +571,11 @@ load_data_estimates <- function(geography, product = NULL, variables = NULL,
     stop("You have supplied an invalid or inactive API key. To obtain a valid API key, visit https://api.census.gov/data/key_signup.html. To activate your key, be sure to click the link provided to you in the email from the Census Bureau that contained your key.", call. = FALSE)
   }
 
-  dat <- as_tibble(fromJSON(content), .name_repair = "minimal")
+  dat <- fromJSON(content)
 
   colnames(dat) <- dat[1,]
+
+  dat <- as_tibble(dat)
 
   dat <- dat[-1,]
 

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -236,7 +236,7 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
     stop("You have supplied an invalid or inactive API key. To obtain a valid API key, visit https://api.census.gov/data/key_signup.html. To activate your key, be sure to click the link provided to you in the email from the Census Bureau that contained your key.", call. = FALSE)
   }
 
-  dat <- tbl_df(fromJSON(content))
+  dat <- as_tibble(fromJSON(content), .name_repair = "minimal")
 
   colnames(dat) <- dat[1,]
 
@@ -393,7 +393,7 @@ load_data_decennial <- function(geography, variables, key, year,
 
   }
 
-  dat <- tbl_df(fromJSON(content))
+  dat <- as_tibble(fromJSON(content), .name_repair = "minimal")
 
   colnames(dat) <- dat[1,]
 
@@ -567,7 +567,7 @@ load_data_estimates <- function(geography, product = NULL, variables = NULL,
     stop("You have supplied an invalid or inactive API key. To obtain a valid API key, visit https://api.census.gov/data/key_signup.html. To activate your key, be sure to click the link provided to you in the email from the Census Bureau that contained your key.", call. = FALSE)
   }
 
-  dat <- tbl_df(fromJSON(content))
+  dat <- as_tibble(fromJSON(content), .name_repair = "minimal")
 
   colnames(dat) <- dat[1,]
 

--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -66,7 +66,7 @@ load_variables <- function(year, dataset, cache = FALSE) {
 
       out2 <- out1[!grepl("Margin Of Error|Margin of Error", out1$label), ]
 
-      return(tbl_df(out2))
+      return(as_tibble(out2))
     # Otherwise use HTML scraping as JSON is not available for decennial Census
     } else {
 
@@ -93,7 +93,7 @@ load_variables <- function(year, dataset, cache = FALSE) {
 
       out2 <- out1[!grepl("Margin Of Error|Margin of Error", out1$label), ]
 
-      return(tbl_df(out2))
+      return(as_tibble(out2))
 
     }
 


### PR DESCRIPTION
This fixes #128 by replacing the deprecated `tbl_df()` with `as_tibble(x, .name_repair = "minimal")` . Error when using dev version of `tibble` was caused by [new name checking/repair defaults in `as_tibble`]( https://github.com/tidyverse/tibble/blob/master/NEWS.md#breaking-changes).

I've tested it a bit with the current CRAN version of tibble (1.4.2) and it seems to be working with both the CRAN version and the dev version (1.4.99.9005).