### PR TITLE
Fix `get_decennial` after API update

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -274,19 +274,10 @@ load_data_decennial <- function(geography, variables, key, year,
     vars_to_get <- paste0(var, ",NAME")
   }
 
-  if (year == 2010) {
-    base <- paste0("https://api.census.gov/data/",
-                   year,
-                   "/dec/",
-                   sumfile)
-  } else {
-    base <- paste0("https://api.census.gov/data/",
+  base <- paste0("https://api.census.gov/data/",
                    year,
                    "/",
                    sumfile)
-  }
-
-
 
 
   for_area <- paste0(geography, ":*")


### PR DESCRIPTION
Hi,

the `get_decennial` function is broken for 2010 SF1 data. I think(!) this is because of an API update. Here is some code that fails in the current version on github:

```
get_decennial("county", state = "36", variables = "PCT012I001", year = 2010)
```

My pull request fixes that problem by removing the "/dec/" part from the base url for 2010 decennial census data. 