### PR TITLE
Return informative error message for multiple county matches

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -2,7 +2,7 @@
 #
 # returns NULL if input is NULL
 # returns valid state FIPS code if input is even pseud-valid (i.e. single digit but w/in range)
-# returns NULL if input is not a valid FIPS code
+# returns error if input is not a valid FIPS code
 validate_state <- function(state, .msg=interactive()) {
 
   if (is.null(state)) return(NULL)
@@ -26,8 +26,8 @@ validate_state <- function(state, .msg=interactive()) {
                 call.=FALSE)
         return(state_sub)
       } else {
-        warning(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
-        return(NULL)
+        stop(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
+
       }
     }
 
@@ -50,13 +50,13 @@ validate_state <- function(state, .msg=interactive()) {
       return(fips_state_table[fips_state_table$name == state, "fips"])
 
     } else {
-      warning(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
-      return(NULL)
+      stop(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
+
     }
 
   } else {
-    warning(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
-    return(NULL)
+    stop(sprintf("'%s' is not a valid FIPS code or state name/abbreviation", state), call.=FALSE)
+
   }
 
 }
@@ -94,9 +94,8 @@ validate_county <- function(state, county, .msg = interactive()) {
 
     if (length(matching_counties) == 0) {
 
-      warning(sprintf("'%s' is not a valid name for counties in %s", county, county_table$state_name[1]),
+      stop(sprintf("'%s' is not a valid name for counties in %s", county, county_table$state_name[1]),
               call. = FALSE)
-      return(NULL)
 
     } else if (length(matching_counties) == 1) {
 
@@ -111,8 +110,8 @@ validate_county <- function(state, county, .msg = interactive()) {
 
       ctys <- format_vec(matching_counties)
 
-      warning("Your county string matches ", ctys, " Please refine your selection.", call. = FALSE)
-      return(NULL)
+      stop("Your county string matches ", ctys, " Please refine your selection.", call. = FALSE)
+
 
     }
 


### PR DESCRIPTION
In response to #161, this changes the error handling for `validate_state()` and `validate_county()` so an error message is returned (instead of `NULL`) if a user enters a county that is not valid or matches multiple valid counties in the lookup. @walkerke, I'm not sure if no longer returning NULL will break something else down the line, but in a little ad-hoc testing I did, I didn't run into any problems.

Currently you get this:
```
> get_acs(
+   geography = "county",
+   variables = "B19013_001",
+   state = "TX",
+   county = "Harris"
+ )
Getting data from the 2013-2017 5-year ACS
Using FIPS code '48' for state 'TX'
Error: Result 1 must be a single string, not NULL of length 0
Call `rlang::last_error()` to see a backtrace
> 
```

With this PR you get:
```
> get_acs(
+   geography = "county",
+   variables = "B19013_001",
+   state = "TX",
+   county = "Harris"
+ )
Getting data from the 2013-2017 5-year ACS
Using FIPS code '48' for state 'TX'
 Error: Your county string matches Harris County, and Harrison County. Please refine your selection. > 
```