### PR TITLE
use old end point for 2009 api in load_variables

### DIFF
--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -26,7 +26,7 @@ load_variables <- function(year, dataset, cache = FALSE) {
     rds <- gsub("/", "_", rds)
   }
 
-  if (grepl("acs1", dataset) || grepl("acs5", dataset)) {
+  if (year > 2009 && (grepl("acs1", dataset) || grepl("acs5", dataset))) {
     dataset <- paste0("acs/", dataset)
   }
 


### PR DESCRIPTION
This fixes https://github.com/walkerke/tidycensus/issues/122#issuecomment-499181316, by using the old API endpoint when running `load_variables()` for `year = 2009`.