### PR TITLE
remove ACS1 pre-2012 limitation

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -129,9 +129,6 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
   }
 
   if (survey == "acs1") {
-    if (year < 2012) {
-      stop("The acs1 data is currently available beginning in 2012. Please select a different year.", call. = FALSE)
-    }
     message("The one-year ACS provides data for geographies with populations of 65,000 and greater.")
   }
 


### PR DESCRIPTION
The census API now allows users to access 1 year acs data for 2010 and 2011. In response to issue #199, I removed the legacy stop that halts get_acs if user requests data from before 2012.

I could have adjusted the if statement to stop the function if a pre-2010 date was entered, but (hopefully!) the good folks at the census will eventually make 2005-2009 1 year data available via the API. Considering many other mis-specifications can cause get_acs's GET command to fail in a less pretty manner (for example specifying a year of data that does not yet exist) it didn't seem necessary to me to keep the stop at all. 

Heads up this is my first time contributing to code before--feedback welcome, I'm looking to learn. Thanks for this awesome tool!