### PR TITLE
Fix bug where 'C' variables are dropped if included with 'B' variables in a single get_acs call

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -258,12 +258,12 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
   # are requested - take care of this under the hood by having the function
   # call itself for "B" variables, "S" variabls and "DP" variables then combining the results
 
-  if (length(unique(substr(variables, 1, 1))) > 1) {
+  if (length(unique(substr(variables, 1, 1))) > 1 && !all(unique(substr(variables, 1, 1)) %in% c("B", "C"))) {
 
-    message('Fetching data by table type ("B", "S", "DP") and combining the result.')
+    message('Fetching data by table type ("B/C", "S", "DP") and combining the result.')
 
     # split variables by type into list, discard empty list elements
-    vars_by_type <- map(c("^B", "^S", "^D"), ~ str_subset(variables, .x)) %>%
+    vars_by_type <- map(c("^B|^C", "^S", "^D"), ~ str_subset(variables, .x)) %>%
       purrr::compact()
 
     if (geometry) {


### PR DESCRIPTION
Oops! As reported in #216, I forgot about subject tables that begin with `C`, so when I added the logic to enable subject, profile, and summary tables in a single `get_acs()` call, it dropped any variables starting with `C`.

This fix should take care of it!

``` r
library(tidycensus)

minilist <- c("C17002_002","C17002_003","C21007_027","C21007_030",
              "B01001_001","B01001_020","B01001_021","B08301_003","B08301_021")

test <- get_acs(
  "block group",
  variables = minilist,
  state = "OH",
  county = "Cuyahoga",
  year = 2017
)
#> Getting data from the 2013-2017 5-year ACS

all(minilist %in% unique(test$variable))
#> [1] TRUE

# check that this also works when requesting, B, C, S, and DP vars
get_acs(
  geography = "state",
  variables = c("C17002_002", "B01001_001", "S1701_C03_002", "DP02_0045")
)
#> Getting data from the 2014-2018 5-year ACS
#> Fetching data by table type ("B/C", "S", "DP") and combining the result.
#> # A tibble: 208 x 5
#>    GEOID NAME    variable       estimate    moe
#>    <chr> <chr>   <chr>             <dbl>  <dbl>
#>  1 01    Alabama B01001_001    4864680     NA  
#>  2 01    Alabama C17002_002     360959   8202  
#>  3 01    Alabama S1701_C03_002      25.1    0.6
#>  4 01    Alabama DP02_0045       10137    809  
#>  5 02    Alaska  B01001_001     738516     NA  
#>  6 02    Alaska  C17002_002      35602   1633  
#>  7 02    Alaska  S1701_C03_002      15.2    0.9
#>  8 02    Alaska  DP02_0045        1455    244  
#>  9 04    Arizona B01001_001    6946685     NA  
#> 10 04    Arizona C17002_002     509325   9122  
#> # … with 198 more rows
```

<sup>Created on 2020-01-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>