### PR TITLE
Avoid warnings in moe_prop from square roots of negatives

### DIFF
--- a/R/moe.R
+++ b/R/moe.R
@@ -48,10 +48,13 @@ moe_prop <- function(num, denom, moe_num, moe_denom) {
 
   prop <- num / denom
 
+  result <- moe_ratio(num = num, denom = denom, moe_num = moe_num, moe_denom = moe_denom)
+
   x <- moe_num^2 - (prop^2 * moe_denom^2)
 
-  result <- ifelse(x < 0, moe_ratio(num = num, denom = denom, moe_num = moe_num, moe_denom = moe_denom),
-                   sqrt(x) / denom)
+  pos_x <- x >= 0
+
+  result[pos_x] <- sqrt(x[pos_x]) / denom[pos_x]
 
   return(result)
 }


### PR DESCRIPTION
When `moe_prop` avoids using a result based on the square root of a negative
number, it can still calculate it and raise a warning.
This is because `ifelse` usually evaluates both possible vectors, and then
picks which elements to use.