### PR TITLE
Make alias for "block group" as "cbg"

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -160,6 +160,8 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
   if (geography == "cbsa") geography <- "metropolitan statistical area/micropolitan statistical area"
 
+  if (geography == "cbg") geography <- "block group"
+
   if (geography == "zcta") geography <- "zip code tabulation area"
 
   if (geography == "zip code tabulation area" && (!is.null(state) || !is.null(county))) {

--- a/R/census.R
+++ b/R/census.R
@@ -70,6 +70,8 @@ get_decennial <- function(geography, variables = NULL, table = NULL, cache_table
 
   # Right now, block groups are only available by tract, which tidycensus won't support
   # Stop if this is called
+  if (geography == "cbg") geography <- "block group"
+
   if (geography == "block group") {
     stop("At the moment block groups are not supported by `get_decennial()` due to API limitations. We recommend downloading data from NHGIS until this is resolved.")
   }


### PR DESCRIPTION
Allow users to specify geography="cbg" for "block group"