### PR TITLE
Supplemental estimates

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -262,10 +262,10 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
   if (length(unique(substr(variables, 1, 1))) > 1 && !all(unique(substr(variables, 1, 1)) %in% c("B", "C"))) {
 
-    message('Fetching data by table type ("B/C", "S", "DP") and combining the result.')
+    message('Fetching data by table type ("B/C", "S", "DP", "K") and combining the result.')
 
     # split variables by type into list, discard empty list elements
-    vars_by_type <- map(c("^B|^C", "^S", "^D"), ~ str_subset(variables, .x)) %>%
+    vars_by_type <- map(c("^B|^C", "^S", "^D", "^K"), ~ str_subset(variables, .x)) %>%
       purrr::compact()
 
     if (geometry) {

--- a/R/acs.R
+++ b/R/acs.R
@@ -95,6 +95,24 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
     stop("Only one table may be requested per call.", call. = FALSE)
   }
 
+  if (!is.null(variables)) {
+    if (any(grepl("^K[0-9].", variables))) {
+      message("Getting data from the ACS 1-year Supplemental Estimates.  Data are available for geographies with populations of 20,000 and greater.")
+      survey <- "acsse"
+
+    }
+  }
+
+  if (!is.null(table)) {
+    if (grepl("^K[0-9].", table)) {
+      message("Getting data from the ACS 1-year Supplemental Estimates.  Data are available for geographies with populations of 20,000 and greater.")
+      survey <- "acsse"
+
+    }
+  }
+
+
+
   if (survey == "acs1") {
     message(sprintf("Getting data from the %s 1-year ACS", year))
   } else if (survey == "acs3") {
@@ -262,10 +280,15 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
   if (length(unique(substr(variables, 1, 1))) > 1 && !all(unique(substr(variables, 1, 1)) %in% c("B", "C"))) {
 
-    message('Fetching data by table type ("B/C", "S", "DP", "K") and combining the result.')
+    if (any(grepl("^K[0-9].", variables))) {
+      stop("At the moment, supplemental estimates variables cannot be combined with variables from other datasets.", call. = FALSE)
+
+    }
+
+    message('Fetching data by table type ("B/C", "S", "DP") and combining the result.')
 
     # split variables by type into list, discard empty list elements
-    vars_by_type <- map(c("^B|^C", "^S", "^D", "^K"), ~ str_subset(variables, .x)) %>%
+    vars_by_type <- map(c("^B|^C", "^S", "^D"), ~ str_subset(variables, .x)) %>%
       purrr::compact()
 
     if (geometry) {
@@ -613,6 +636,8 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
       survey2 <- paste0(survey, "/subject")
     } else if (grepl("^DP[0-9].", table)) {
       survey2 <- paste0(survey, "/profile")
+    } else if (grepl("^K[0-9].", table)) {
+      survey2 <- "acsse"
     } else {
       survey2 <- survey
     }

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -145,6 +145,12 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
                   as.character(year),
                   survey, sep = "/")
   } else {
+    if (grepl("^K[0-9].", formatted_variables)) {
+      message("Using the ACS Supplemental Estimates")
+    }
+
+    survey <- "acsse"
+
     base <- paste("https://api.census.gov/data",
                   as.character(year), "acs",
                   survey, sep = "/")
@@ -162,10 +168,7 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
     base <- paste0(base, "/subject")
   }
 
-  if (grepl("^K[0-9].", formatted_variables)) {
-    message("Using the ACS Supplemental Estimates")
-    base <- paste0(base, "/acsse")
-  }
+
 
   for_area <- paste0(geography, ":*")
 

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -162,6 +162,11 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
     base <- paste0(base, "/subject")
   }
 
+  if (grepl("^K[0-9].", formatted_variables)) {
+    message("Using the ACS Supplemental Estimates")
+    base <- paste0(base, "/acsse")
+  }
+
   for_area <- paste0(geography, ":*")
 
   if (!is.null(state)) {

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -145,11 +145,6 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
                   as.character(year),
                   survey, sep = "/")
   } else {
-    if (grepl("^K[0-9].", formatted_variables)) {
-      message("Using the ACS Supplemental Estimates")
-    }
-
-    survey <- "acsse"
 
     base <- paste("https://api.census.gov/data",
                   as.character(year), "acs",

--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -30,7 +30,7 @@ load_variables <- function(year, dataset, cache = FALSE) {
     rds <- gsub("/", "_", rds)
   }
 
-  if (year > 2009 && (grepl("acs1", dataset) || grepl("acs5", dataset))) {
+  if (year > 2009 && (grepl("acs1", dataset) || grepl("acs5", dataset)) || grepl("acsse", dataset)) {
     dataset <- paste0("acs/", dataset)
   }
 
@@ -44,7 +44,7 @@ load_variables <- function(year, dataset, cache = FALSE) {
     set <- paste(year, d, sep = "/")
 
     # If ACS, use JSON parsing to speed things up
-    if (grepl("acs[135]", d)) {
+    if (grepl("acs[135]|acsse", d)) {
 
       url <- paste("https://api.census.gov/data",
                    set,
@@ -64,7 +64,7 @@ load_variables <- function(year, dataset, cache = FALSE) {
 
       names(out) <- tolower(names(out))
 
-      out1 <- out[grepl("^B[0-9]|^C[0-9]|^DP[0-9]|^S[0-9]|^P[0-9]|^H[0-9]", out$name), ]
+      out1 <- out[grepl("^B[0-9]|^C[0-9]|^DP[0-9]|^S[0-9]|^P[0-9]|^H[0-9]|^K[0-9]", out$name), ]
 
       out1$name <- str_replace(out1$name, "E$|M$", "")
 
@@ -129,7 +129,7 @@ load_variables <- function(year, dataset, cache = FALSE) {
         }
 
 
-        out1 <- out[grepl("^B[0-9]|^C[0-9]|^DP[0-9]|^S[0-9]|^P[0-9]|^H[0-9]", out$name), ]
+        out1 <- out[grepl("^B[0-9]|^C[0-9]|^DP[0-9]|^S[0-9]|^P[0-9]|^H[0-9]|^K[0-9]", out$name), ]
 
         out1$name <- str_replace(out1$name, "E$|M$", "")
 


### PR DESCRIPTION
This PR adds support in `get_acs()` for the [ACS 1-year Supplemental Estimates API](https://www.census.gov/data/developers/data-sets/ACS-supplemental-data.html), which gives 1-year estimates for smaller geographies (down to population 20,000 and up).  Variables in the supplemental estimates start with K.  