### PR TITLE
fix get_decennial() to work with dplyr 1.0 when requesting >48 vars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ Imports:
     utils
 Suggests: 
     ggplot2
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/census.R
+++ b/R/census.R
@@ -294,7 +294,7 @@ get_decennial <- function(geography, variables = NULL, table = NULL, cache_table
       }
       d
     }) %>%
-      bind_cols()
+      reduce(left_join, by = c("GEOID", "NAME"))
   } else {
     dat <- try(load_data_decennial(geography, variables, key, year, sumfile, state, county, show_call = show_call),
                silent = TRUE)

--- a/man/county_laea.Rd
+++ b/man/county_laea.Rd
@@ -4,7 +4,9 @@
 \name{county_laea}
 \alias{county_laea}
 \title{County geometry with Alaska and Hawaii shifted and re-scaled}
-\format{An object of class \code{sf} (inherits from \code{data.frame}) with 3143 rows and 2 columns.}
+\format{
+An object of class \code{sf} (inherits from \code{data.frame}) with 3143 rows and 2 columns.
+}
 \usage{
 data(county_laea)
 

--- a/man/fips_codes.Rd
+++ b/man/fips_codes.Rd
@@ -4,7 +4,9 @@
 \name{fips_codes}
 \alias{fips_codes}
 \title{Dataset with FIPS codes for US states and counties}
-\format{An object of class \code{data.frame} with 3237 rows and 5 columns.}
+\format{
+An object of class \code{data.frame} with 3237 rows and 5 columns.
+}
 \usage{
 data(fips_codes)
 }

--- a/man/state_laea.Rd
+++ b/man/state_laea.Rd
@@ -4,7 +4,9 @@
 \name{state_laea}
 \alias{state_laea}
 \title{State geometry with Alaska and Hawaii shifted and re-scaled}
-\format{An object of class \code{sf} (inherits from \code{data.frame}) with 51 rows and 2 columns.}
+\format{
+An object of class \code{sf} (inherits from \code{data.frame}) with 51 rows and 2 columns.
+}
 \usage{
 data(state_laea)
 


### PR DESCRIPTION
Looks like this small change will fix the error reported in #229. Here it is working with dplyr 0.8.99.9002 and sf 0.9.0 installed.

This dplyr change doesn't seem to impact `get_acs()` with large numbers of variables as the logic for combining the returned tibbles is different in `get_acs()`: https://github.com/mfherman/tidycensus/blob/d41bbc5f3c30d85506e654f7303e51080144d4c8/R/acs.R#L659

``` r
library(tidycensus)

vars <- load_variables(2010, "sf1", cache = TRUE)

get_decennial(
  geography = "state",
  state = "VT",
  variables = vars$name[1:49]
)
#> Getting data from the 2010 decennial Census
#> # A tibble: 49 x 4
#>    GEOID NAME    variable  value
#>    <chr> <chr>   <chr>     <dbl>
#>  1 50    Vermont H001001  322539
#>  2 50    Vermont H002001  322539
#>  3 50    Vermont H002002  106561
#>  4 50    Vermont H002003   45774
#>  5 50    Vermont H002004   60787
#>  6 50    Vermont H002005  215978
#>  7 50    Vermont H002006       0
#>  8 50    Vermont H003001  322539
#>  9 50    Vermont H003002  256442
#> 10 50    Vermont H003003   66097
#> # … with 39 more rows

get_decennial(
  geography = "state",
  state = "VT",
  variables = vars$name[1:49],
  geometry = TRUE
)
#> Getting data from the 2010 decennial Census
#> Simple feature collection with 49 features and 4 fields
#> geometry type:  MULTIPOLYGON
#> dimension:      XY
#> bbox:           xmin: -73.43774 ymin: 42.72685 xmax: -71.46455 ymax: 45.01666
#> CRS:            4269
#> # A tibble: 49 x 5
#>    GEOID NAME   variable  value                                         geometry
#>    <chr> <chr>  <chr>     <dbl>                               <MULTIPOLYGON [°]>
#>  1 50    Vermo… H001001  322539 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  2 50    Vermo… H002001  322539 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  3 50    Vermo… H002002  106561 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  4 50    Vermo… H002003   45774 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  5 50    Vermo… H002004   60787 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  6 50    Vermo… H002005  215978 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  7 50    Vermo… H002006       0 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  8 50    Vermo… H003001  322539 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#>  9 50    Vermo… H003002  256442 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#> 10 50    Vermo… H003003   66097 (((-72.04008 44.15575, -72.04271 44.15227, -72.…
#> # … with 39 more rows
```

<sup>Created on 2020-04-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>