### PR TITLE
Fixing bad behavior in moe_prop when values involve NA

### DIFF
--- a/R/moe.R
+++ b/R/moe.R
@@ -52,7 +52,7 @@ moe_prop <- function(num, denom, moe_num, moe_denom) {
 
   x <- moe_num^2 - (prop^2 * moe_denom^2)
 
-  pos_x <- x >= 0
+  pos_x <- x >= 0 & !is.na(x)
 
   result[pos_x] <- sqrt(x[pos_x]) / denom[pos_x]
 


### PR DESCRIPTION
Adjusting logic for when x is NA. Cannot use index with NA

``` r
# Original index
x <- c(1, 2, 3, 4, 0, -1, NA)
y <- 1:length(x)*100
(pos_x <- x >= 0 )
#> [1]  TRUE  TRUE  TRUE  TRUE  TRUE FALSE    NA
y[pos_x] <- x[pos_x]
#> Error in y[pos_x] <- x[pos_x]: NAs are not allowed in subscripted assignments
y
#> [1] 100 200 300 400 500 600 700

# Better index
x <- c(1, 2, 3, 4, 0, -1, NA)
y <- 1:length(x)*100
(pos_x <- x >= 0 & !is.na(x))
#> [1]  TRUE  TRUE  TRUE  TRUE  TRUE FALSE FALSE
y[pos_x] <- x[pos_x]
y
#> [1]   1   2   3   4   0 600 700
```

<sup>Created on 2020-04-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>