### PR TITLE
implement rep_weights argument for get_pums()

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -706,8 +706,8 @@ load_data_pums <- function(variables, state, key, year, survey, recode, show_cal
   # necessary to match data dictionary codes and
   # convert variables to numeric according to data dictionary
 
-  # But wait, this only works when the serial numbers are correctly returned and they are not for 2018 right now
-  if(year != 2018) {
+  # But wait, this only works when the serial numbers are correctly returned and and we have a variable metadata in pums_variables
+  if(year == 2017) {
     var_val_length <- pums_variables_filter %>%
       filter(!is.na(.data$val_length)) %>%
       distinct(.data$var_code, .data$val_length, .data$val_na)
@@ -747,7 +747,7 @@ load_data_pums <- function(variables, state, key, year, survey, recode, show_cal
   # Do you want to return value labels also?
   if(recode) {
 
-    # Only works for 2017 for now because 2017 is only year included in pums_variables
+    # Only works for 2017 because it's the only year included in pums_variables for now
     if(year == 2017) {
       var_lookup <- pums_variables_filter %>%
         select(.data$var_code, val = .data$val_min, .data$val_label)

--- a/R/pums.R
+++ b/R/pums.R
@@ -87,9 +87,15 @@ get_pums <- function(variables,
                      recode = recode,
                      show_call = show_call,
                      key = key)
-        }) %>%
-      reduce(left_join, by = c("SERIALNO", "SPORDER", "WGTP", "PWGTP", "ST")) %>%
-      select(-contains("WGTP"), everything(), contains("WGTP"))
+        })
+
+    if(recode) {
+      pums_data <- reduce(pums_data, left_join, by = c("SERIALNO", "SPORDER", "WGTP", "PWGTP", "ST", "ST_label"))
+    } else {
+      pums_data <- reduce(pums_data, left_join, by = c("SERIALNO", "SPORDER", "WGTP", "PWGTP"))
+    }
+
+    pums_data <- select(pums_data, -contains("WGTP"), everything(), contains("WGTP"))
       } else {
         pums_data <- load_data_pums(variables = variables,
                                     state = state,
@@ -110,7 +116,6 @@ get_pums <- function(variables,
   }
   return(pums_data)
 }
-
 
 
 #' Convert a data frame returned by get_pums() to a survey design object

--- a/R/pums.R
+++ b/R/pums.R
@@ -54,19 +54,30 @@ get_pums <- function(variables,
 
   }
 
-  if(rep_weights == "housing") {
-    variables <- c(variables, housing_weight_variables)
-  }
-  if(rep_weights == "person") {
-    variables <- c(variables, person_weight_variables)
-  }
-  if(rep_weights == "both") {
-    variables <- c(variables, housing_weight_variables, person_weight_variables)
+  if(!is.null(rep_weights)) {
+    if(year == 2018) {
+    stop("Cannot request replicate weights for 2018 PUMS because household serial numbers are not available from the API at the moment and each API call is limited to 50 variables.",
+         call. = FALSE)
+    } else {
+      if(rep_weights == "housing") {
+        variables <- c(variables, housing_weight_variables)
+      }
+      if(rep_weights == "person") {
+        variables <- c(variables, person_weight_variables)
+        }
+      if(rep_weights == "both") {
+        variables <- c(variables, housing_weight_variables, person_weight_variables)
+        }
+      }
   }
 
   ## If more than 46 vars requested, split into multiple API calls and join the result
   ## this works, but repeats pulling the weight and ST vars
   if (length(variables) > 46) {
+    if(year == 2018) {
+      stop("Cannot request more than 46 variables in a single call for 2018 PUMS because household serial numbers are not available from the API at the moment.",
+           call. = FALSE)
+    }
     l <- split(variables, ceiling(seq_along(variables) / 46))
     pums_data <- map(l, function(x) {
       load_data_pums(variables = x,
@@ -122,6 +133,7 @@ get_pums <- function(variables,
 #' \dontrun{
 #' pums <- get_pums(variables = "AGEP", state = "VT", rep_weights = "person")
 #' pums_design <- df_to_svyrep(pums, type = "person")
+#' survey::svymean(~AGEP, pums_design)
 #' }
 df_to_svyrep <- function(df, type = "person") {
 

--- a/man/df_to_svyrep.Rd
+++ b/man/df_to_svyrep.Rd
@@ -27,5 +27,6 @@ This helper function takes a data frame returned by
 \dontrun{
 pums <- get_pums(variables = "AGEP", state = "VT", rep_weights = "person")
 pums_design <- df_to_svyrep(pums, type = "person")
+survey::svymean(~AGEP, pums_design)
 }
 }


### PR DESCRIPTION
Not sure if this is what you had in mind for the `rep_weights` argument. I also borrowed some logic from the other load_* functions to split the variable vector when too large. The PUMS API endpoint seems to take up to 50 variables in one call.

Also created a little wrapper around `survey::svrepdesign()` to create a survey object. Not sure if this belongs in tidycensus, or as you said just in a vignette about how to analyze PUMS data.