### PR TITLE
remove deprecated `funs()` from get_acs()

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -684,7 +684,7 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
     moex <- function(x) x * moe_factor
 
     dat2 <- dat %>%
-      mutate_if(grepl("*M$", names(.)), funs(moex))
+      mutate_if(grepl("*M$", names(.)), moex)
 
     if (!is.null(names(variables))) {
       for (i in 1:length(variables)) {


### PR DESCRIPTION
In re this warning message when `output = "wide"` in `get_acs()`. I don't believe the `funs()` wrapper has been needed for a while, so this shouldn't impact anything. Candidly, I didn't spend much time testing, @walkerke you might want to kick the tires just a bit!

```r
Warning message:
`funs()` is deprecated as of dplyr 0.8.0.
Please use a list of either functions or lambdas: 

  # Simple named list: 
  list(mean = mean, median = median)

  # Auto named with `tibble::lst()`: 
  tibble::lst(mean, median)

  # Using lambdas
  list(~ mean(., trim = .2), ~ median(., na.rm = TRUE))
This warning is displayed once every 8 hours.
Call `lifecycle::last_warnings()` to see where this warning was generated. 
```