### PR TITLE
Update dplyr to 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ matrix:
     include:
         - os: linux
           r: release
-          dist: trusty # 14.04
+          dist: bionic # 14.04
           env: R_CODECOV=true
         - os: linux
           r: devel
-          dist: trusty
+          dist: bionic
 
 before_install:
     - sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable --yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends: R (>= 3.3.0)
 Imports:
     httr,
     sf,
-    dplyr (>= 0.8.5),
+    dplyr (>= 0.8.0),
     tigris,
     stringr,
     jsonlite (>= 1.5.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends: R (>= 3.3.0)
 Imports:
     httr,
     sf,
-    dplyr (>= 0.7.0),
+    dplyr (>= 0.8.5),
     tigris,
     stringr,
     jsonlite (>= 1.5.0),

--- a/R/acs.R
+++ b/R/acs.R
@@ -681,10 +681,8 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
     # dat[[moe_vars]] <- apply(dat[[moe_vars]], 2, function(x) round(x * moe_factor, 0))
 
-    moex <- function(x) x * moe_factor
-
     dat2 <- dat %>%
-      mutate_if(grepl("*M$", names(.)), funs(moex))
+      mutate_if(grepl("*M$", names(.)), list(~(. * moe_factor)))
 
     if (!is.null(names(variables))) {
       for (i in 1:length(variables)) {

--- a/R/significance.R
+++ b/R/significance.R
@@ -8,7 +8,7 @@
 #'
 #' @seealso https://www.census.gov/content/dam/Census/library/publications/2018/acs/acs_general_handbook_2018_ch07.pdf
 #'
-#' @return TRUE if the difference is statistically signifiance, FALSE otherwise.
+#' @return TRUE if the difference is statistically signifiant, FALSE otherwise.
 #' @export
 significance <- function(est1, est2, moe1, moe2, clevel = 0.9){
   # generate z score

--- a/man/significance.Rd
+++ b/man/significance.Rd
@@ -18,7 +18,7 @@ significance(est1, est2, moe1, moe2, clevel = 0.9)
 \item{clevel}{The confidence level. May by 0.9, 0.95, or 0.99}
 }
 \value{
-TRUE if the difference is statistically signifiance, FALSE otherwise.
+TRUE if the difference is statistically signifiant, FALSE otherwise.
 }
 \description{
 Evaluate whether the difference in two estimates is statistically significant.


### PR DESCRIPTION
get_acs now throws a warning for the mutate_if call using the depreciated `funs`. Updated to 0.8.0 `list` syntax instead. Note that list is supercede in 1.0, but not depreciated, so I've defaulted to 0.8.0 to maximize compatibility.