### PR TITLE
2000 decennial endpoint update

### DIFF
--- a/R/census.R
+++ b/R/census.R
@@ -99,8 +99,8 @@ get_decennial <- function(geography, variables = NULL, table = NULL, cache_table
     stop("Summary File 3 was not released in 2010. Use Summary File 1 or tables from the American Community Survey via get_acs() instead.", call. = FALSE)
   }
 
-  if (geography == "block" && year != 2010) {
-    stop("At the moment, block data is only available for 2010. I recommend using NHGIS (http://www.nhgis.org) and the ipumsr package for block data for other years.", call. = FALSE)
+  if (geography == "block" && year == 1990) {
+    stop("At the moment, block data is not available for 1990. I recommend using NHGIS (http://www.nhgis.org) and the ipumsr package for block data for other years.", call. = FALSE)
   }
 
   # if (geography %in% c("tract", "block group") && year == 1990 && is.null(county)) {

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -288,7 +288,7 @@ load_data_decennial <- function(geography, variables, key, year, sumfile,
     vars_to_get <- paste0(var, ",NAME")
   }
 
-  if (year == 2010) {
+  if (year == 2010 || (year == 2000 && sumfile == "sf1")) {
     base <- paste0("https://api.census.gov/data/",
                    year,
                    "/dec/",

--- a/vignettes/basic-usage.Rmd
+++ b/vignettes/basic-usage.Rmd
@@ -47,9 +47,9 @@ If __state__ or __county__ is in bold face in "Available by", you are required t
 
 |Geography|Definition|Available by|Available in|
 |---------|----------|------------|------------|
-|`"us"`|United States||`get_acs()`| 
-|`"region"`|Census region||`get_acs()`| 
-|`"division"`|Census division||`get_acs()`| 
+|`"us"`|United States||`get_acs()`, `get_decennial()`| 
+|`"region"`|Census region||`get_acs()`, `get_decennial()`| 
+|`"division"`|Census division||`get_acs()`, `get_decennial()`| 
 |`"state"`|State or equivalent|state|`get_acs()`, `get_decennial()`| 
 |`"county"`|County or equivalent|state, county|`get_acs()`, `get_decennial()`| 
 |`"county subdivision"`|County subdivision|__state__, county|`get_acs()`, `get_decennial()`| 
@@ -59,17 +59,17 @@ If __state__ or __county__ is in bold face in "Available by", you are required t
 |`"place"`|Census-designated place|state|`get_acs()`, `get_decennial()`|  
 |`"alaska native regional corporation"`|Alaska native regional corporation|state|`get_acs()`, `get_decennial()`|  
 |`"american indian area/alaska native area/hawaiian home land"`|Federal and state-recognized American Indian reservations and Hawaiian home lands|state|`get_acs()`, `get_decennial()`|  
-|`"american indian area/alaska native area (reservation or statistical entity only)"`|Only reservations and statistical entities|state|`get_acs()`| 
+|`"american indian area/alaska native area (reservation or statistical entity only)"`|Only reservations and statistical entities|state|`get_acs()`, `get_decennial()`| 
 |`"american indian area (off-reservation trust land only)/hawaiian home land"`|Only off-reservation trust lands and Hawaiian home lands|state|`get_acs()`| 
 |`"metropolitan statistical area/micropolitan statistical area"`|Core-based statistical area|state|`get_acs()`, `get_decennial()`|
-|`"combined statistical area"`|Combined statistical area|state|`get_acs()`| 
-|`"new england city and town area"`|New England city/town area|state|`get_acs()`| 
-|`"combined new england city and town area"`|Combined New England area|state|`get_acs()`| 
-|`"urban area"`|Census-defined urbanized areas||`get_acs()`| 
+|`"combined statistical area"`|Combined statistical area|state|`get_acs()`, `get_decennial()`| 
+|`"new england city and town area"`|New England city/town area|state|`get_acs()`, `get_decennial()`| 
+|`"combined new england city and town area"`|Combined New England area|state|`get_acs()`, `get_decennial()`| 
+|`"urban area"`|Census-defined urbanized areas||`get_acs()`, `get_decennial()`| 
 |`"congressional district"`|Congressional district for the year-appropriate Congress|state|`get_acs()`, `get_decennial()`|  
-|`"school district (elementary)"`|Elementary school district|__state__|`get_acs()`| 
-|`"school district (secondary)"`|Secondary school district|__state__|`get_acs()`| 
-|`"school district (unified)"`|Unified school district|__state__|`get_acs()`| 
+|`"school district (elementary)"`|Elementary school district|__state__|`get_acs()`, `get_decennial()`| 
+|`"school district (secondary)"`|Secondary school district|__state__|`get_acs()`, `get_decennial()`| 
+|`"school district (unified)"`|Unified school district|__state__|`get_acs()`, `get_decennial()`| 
 |`"public use microdata area"`|PUMA (geography associated with Census microdata samples)|state|`get_acs()`| 
 |`"zip code tabulation area"` OR `"zcta"`|Zip code tabulation area||`get_acs()`, `get_decennial()`|  
 |`"state legislative district (upper chamber)"`|State senate districts|__state__|`get_acs()`, `get_decennial()`|  


### PR DESCRIPTION
2000 decennial data is now available in new endpoint and includes many more geographies than the old endpoint. 

New: https://api.census.gov/data/2000/dec/sf1/geography.html
Old: https://api.census.gov/data/2000/sf1/geography.html

Some discussion [here](https://uscensusbureau.slack.com/archives/CC76279UH/p1598539227002400) and [here](https://uscensusbureau.slack.com/archives/C6DGLC05B/p1598534150024500). Right now, this is only available for Summary File 1. Unclear if SF3 will be added in the future.

I also updated the table in the Basic Usage vignette to reflect newly available geographies in `get_decennial()`.