### PR TITLE
Add option to request a subset of zctas in get_acs()

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -126,7 +126,7 @@ format_variables_acs <- function(variables) {
 }
 
 load_data_acs <- function(geography, formatted_variables, key, year, state = NULL,
-                          county = NULL, survey, show_call = FALSE) {
+                          county = NULL, zcta = NULL, survey, show_call = FALSE) {
 
   base <- paste("https://api.census.gov/data",
                   as.character(year), "acs",
@@ -206,7 +206,17 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
 
   }
 
-  else {
+  else if (!is.null(zcta))  {
+
+    for_area <- paste0(zcta, collapse = ",")
+
+    vars_to_get <- paste0(formatted_variables, ",NAME")
+
+    call <- GET(base, query = list(get = vars_to_get,
+                                   "for" = paste0(geography, ":", for_area),
+                                   key = key))
+
+  } else {
 
     vars_to_get <- paste0(formatted_variables, ",NAME")
 

--- a/man/get_acs.Rd
+++ b/man/get_acs.Rd
@@ -14,6 +14,7 @@ get_acs(
   output = "tidy",
   state = NULL,
   county = NULL,
+  zcta = NULL,
   geometry = FALSE,
   keep_geo_vars = FALSE,
   shift_geo = FALSE,
@@ -60,10 +61,15 @@ Defaults to NULL.}
 FIPS codes are accepted. Must be combined with a value supplied
 to `state`.  Defaults to NULL.}
 
+\item{zcta}{The zip code tabulation area(s) for which you are requesting data.
+Specify a single value or a vector of values to get data for more
+than one ZCTA. Numeric or character ZCTA GEOIDs are accepted.
+When specifying ZCTAs, geography must be set to `"zcta"` and
+`state` and `county` must be `NULL`. Defaults to NULL.}
+
 \item{geometry}{if FALSE (the default), return a regular tibble of ACS data.
 if TRUE, uses the tigris package to return an sf tibble
-with simple feature geometry in the `geometry` column.  state, county, tract, block group,
-block, and ZCTA geometry are supported.}
+with simple feature geometry in the `geometry` column.}
 
 \item{keep_geo_vars}{if TRUE, keeps all the variables from the Census
 shapefile obtained by tigris.  Defaults to FALSE.}


### PR DESCRIPTION
Based on #287, added a new parameter to `get_acs()` to specify one or more ZCTAs. You can pass a numeric or character vector of ZCTAs. When `geometry = TRUE`, entire ZCTA shapefiles are pulled from Census, but only selected ZCTAs are included in results.

I added some error messages if a user specifies ZCTAs and `geography != "ZCTA"`, or if using the `state`/`county` along with the `zcta` argument.

I started to work on adding this option to `get_decennial()` but I realized that there are more geography options with the decennial API so that are you are able to select ZCTAs within states already. Because of this, the GEOIDs used for pulling ZCTA data are state + zip code (e.g. `3610536` rather than just `10536`). This makes it a bit trickier to implement the ability to select ZCTAs in the call, but certainly possible. @walkerke: do you think it's worth building in the ZCTA argument for `get_decennial()`, or is the ability specify ZCTAs with states sufficient?

Here is some code and output with the added feature to `get_acs()`:

``` r
get_acs(
   geography = "zcta",
   variables = "B19013_001",
   zcta = c(10536, 11222, 90210)
   )
# Getting data from the 2014-2018 5-year ACS
# A tibble: 3 x 5
#   GEOID NAME        variable   estimate   moe
#   <chr> <chr>       <chr>         <dbl> <dbl>
# 1 10536 ZCTA5 10536 B19013_001   175833 26113
# 2 11222 ZCTA5 11222 B19013_001    85111  3740
# 3 90210 ZCTA5 90210 B19013_001   143542 16099

get_acs(
  geography = "zcta",
  variables = "B19013_001",
  zcta = c("10536", "11222", "90210"),
   geometry = TRUE
  )
# Getting data from the 2014-2018 5-year ACS
# Simple feature collection with 3 features and 5 fields
# geometry type:  MULTIPOLYGON
# dimension:      XY
# bbox:           xmin: -118.4424 ymin: 34.06705 xmax: -73.61156 ymax: 41.31918
# geographic CRS: NAD83
#   GEOID        NAME   variable estimate   moe                       geometry
# 1 90210 ZCTA5 90210 B19013_001   143542 16099 MULTIPOLYGON (((-118.4396 3...
# 2 10536 ZCTA5 10536 B19013_001   175833 26113 MULTIPOLYGON (((-73.62374 4...
# 3 11222 ZCTA5 11222 B19013_001    85111  3740 MULTIPOLYGON (((-73.96248 4...

get_acs(
   state = "NY",
   geography = "zcta",
   variables = "B19013_001",
   zcta = c(10536, 11222)
   )
# Getting data from the 2014-2018 5-year ACS
# Error: ZCTAs can only be requested for the entire country or by specifying ZCTAs, not within states or counties.

get_acs(
   state = "NY",
   geography = "tract",
   variables = "B19013_001",
   zcta = c(10536, 11222)
   )
# Getting data from the 2014-2018 5-year ACS
# Error: ZCTAs can only be specified when requesting data at the zip code tabulation area-level.
```