### PR TITLE
Fix bug that removed custom names in get_acs when variables from more than one table type requested

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -305,7 +305,7 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
     message('Fetching data by table type ("B/C", "S", "DP") and combining the result.')
 
     # split variables by type into list, discard empty list elements
-    vars_by_type <- map(c("^B|^C", "^S", "^D"), ~ str_subset(variables, .x)) %>%
+    vars_by_type <- map(c("^B|^C", "^S", "^D"), ~ variables[str_detect(variables, .x)]) %>%
       purrr::compact()
 
     if (geometry) {


### PR DESCRIPTION
@walkerke I made a mess of the commit history in the prior PR (#321), so I've just opened a new one here. I probably should get better at git ;)

Small fix that addresses #319 -- previous implementation stripped the names from the variable vector input and thus wouldn't rename variables. This fix keeps the names when splitting the requested variables into a list by table type.