### PR TITLE
Various changes: support for earlier years ACS, enable 200 SF3, simplify load_variables

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -1,55 +1,55 @@
-#' Obtain data and feature geometry for the five-year American Community Survey
+#' Obtain data and feature geometry for the American Community Survey
 #'
 #' @param geography The geography of your data.
 #' @param variables Character string or vector of character strings of variable
-#'                  IDs. tidycensus automatically returns the estimate and the
-#'                  margin of error associated with the variable.
-#' @param table   The ACS table for which you would like to request all variables. Uses
-#'                lookup tables to identify the variables; performs faster when variable
-#'                table already exists through \code{load_variables(cache = TRUE)}.
-#'                Only one table may be requested per call.
-#' @param cache_table Whether or not to cache table names for faster future access.
-#'                    Defaults to FALSE; if TRUE, only needs to be called once per
-#'                    dataset.  If variables dataset is already cached via the
-#'                    \code{load_variables} function, this can be bypassed.
-#' @param year The year, or endyear, of the ACS sample. 2009 through 2018 are
-#'                available. Defaults to 2018.
+#'   IDs. tidycensus automatically returns the estimate and the margin of error
+#'   associated with the variable.
+#' @param table   The ACS table for which you would like to request all
+#'   variables. Uses lookup tables to identify the variables; performs faster
+#'   when variable table already exists through \code{load_variables(cache =
+#'   TRUE)}. Only one table may be requested per call.
+#' @param cache_table Whether or not to cache table names for faster future
+#'   access. Defaults to FALSE; if TRUE, only needs to be called once per
+#'   dataset.  If variables dataset is already cached via the
+#'   \code{load_variables} function, this can be bypassed.
+#' @param year The year, or endyear, of the ACS sample. 5-year ACS data is
+#'   available from 2009 through 2018. 1-year ACS data is available from 2005
+#'   through 2019. Defaults to 2018.
 #' @param endyear Deprecated and will be removed in a future release.
 #' @param output One of "tidy" (the default) in which each row represents an
-#'               enumeration unit-variable combination, or "wide" in which each
-#'               row represents an enumeration unit and the variables are in the
-#'               columns.
-#' @param state An optional vector of states for which you are requesting data. State
-#'              names, postal codes, and FIPS codes are accepted.
-#'              Defaults to NULL.
+#'   enumeration unit-variable combination, or "wide" in which each row
+#'   represents an enumeration unit and the variables are in the columns.
+#' @param state An optional vector of states for which you are requesting data.
+#'   State names, postal codes, and FIPS codes are accepted. Defaults to NULL.
 #' @param county The county for which you are requesting data. County names and
-#'               FIPS codes are accepted. Must be combined with a value supplied
-#'               to `state`.  Defaults to NULL.
-#' @param zcta The zip code tabulation area(s) for which you are requesting data.
-#'             Specify a single value or a vector of values to get data for more
-#'             than one ZCTA. Numeric or character ZCTA GEOIDs are accepted.
-#'             When specifying ZCTAs, geography must be set to `"zcta"` and
-#'             `state` and `county` must be `NULL`. Defaults to NULL.
+#'   FIPS codes are accepted. Must be combined with a value supplied to `state`.
+#'   Defaults to NULL.
+#' @param zcta The zip code tabulation area(s) for which you are requesting
+#'   data. Specify a single value or a vector of values to get data for more
+#'   than one ZCTA. Numeric or character ZCTA GEOIDs are accepted. When
+#'   specifying ZCTAs, geography must be set to `"zcta"` and `state` and
+#'   `county` must be `NULL`. Defaults to NULL.
 #' @param geometry if FALSE (the default), return a regular tibble of ACS data.
-#'                 if TRUE, uses the tigris package to return an sf tibble
-#'                 with simple feature geometry in the `geometry` column.
+#'   if TRUE, uses the tigris package to return an sf tibble with simple feature
+#'   geometry in the `geometry` column.
 #' @param keep_geo_vars if TRUE, keeps all the variables from the Census
-#'                      shapefile obtained by tigris.  Defaults to FALSE.
-#' @param shift_geo if TRUE, returns geometry with Alaska and Hawaii shifted for thematic mapping of the entire US.
-#'                  Geometry was originally obtained from the albersusa R package.
-#' @param summary_var Character string of a "summary variable" from the ACS
-#'                    to be included
-#'                    in your output. Usually a variable (e.g. total population)
-#'                    that you'll want to use as a denominator or comparison.
-#' @param key Your Census API key.
-#'            Obtain one at \url{http://api.census.gov/data/key_signup.html}
-#' @param moe_level The confidence level of the returned margin of error.  One of 90 (the default), 95, or 99.
-#' @param survey The ACS contains one-year, three-year, and five-year surveys expressed as "acs1", "acs3", and "acs5".
-#'               The default selection is "acs5."
-#' @param show_call if TRUE, display call made to Census API. This can be very useful
-#'                  in debugging and determining if error messages returned are
-#'                  due to tidycensus or the Census API. Copy to the API call into
-#'                  a browser and see what is returned by the API directly. Defaults to FALSE.
+#'   shapefile obtained by tigris.  Defaults to FALSE.
+#' @param shift_geo if TRUE, returns geometry with Alaska and Hawaii shifted for
+#'   thematic mapping of the entire US. Geometry was originally obtained from
+#'   the albersusa R package.
+#' @param summary_var Character string of a "summary variable" from the ACS to
+#'   be included in your output. Usually a variable (e.g. total population) that
+#'   you'll want to use as a denominator or comparison.
+#' @param key Your Census API key. Obtain one at
+#'   \url{http://api.census.gov/data/key_signup.html}
+#' @param moe_level The confidence level of the returned margin of error.  One
+#'   of 90 (the default), 95, or 99.
+#' @param survey The ACS contains one-year, three-year, and five-year surveys
+#'   expressed as "acs1", "acs3", and "acs5". The default selection is "acs5."
+#' @param show_call if TRUE, display call made to Census API. This can be very
+#'   useful in debugging and determining if error messages returned are due to
+#'   tidycensus or the Census API. Copy to the API call into a browser and see
+#'   what is returned by the API directly. Defaults to FALSE.
 #' @param ... Other keyword arguments
 #'
 #' @return A tibble or sf tibble of ACS data
@@ -90,8 +90,23 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
                     shift_geo = FALSE, summary_var = NULL, key = NULL,
                     moe_level = 90, survey = "acs5", show_call = FALSE, ...) {
 
-  if (year < 2009) {
-    stop("ACS support in tidycensus begins with the 2005-2009 5-year ACS. Consider using decennial Census data instead.", call. = FALSE)
+  if (survey == "acs5" && year < 2009) {
+    stop("5-year ACS support in tidycensus begins with the 2005-2009 5-year ACS. Consider using decennial Census data instead.", call. = FALSE)
+  }
+
+  if (survey == "acs1") {
+    if (year < 2005) {
+      stop("1-year ACS support in tidycensus begins with the 2005 1-year ACS. Consider using decennial Census data instead.", call. = FALSE)
+    }
+    message("The 1-year ACS provides data for geographies with populations of 65,000 and greater.")
+  }
+
+  if (survey == "acs3") {
+    if (year < 2007 || year > 2013) {
+      stop("3-year ACS support in tidycensus begins with the 2005-2007 3-year ACS and ends with the 2011-2013 3-year ACS. For newer data, use the 1-year or 5-year ACS.", call. = FALSE)
+    } else {
+      message("The 3-year ACS provides data for geographies with populations of 20,000 and greater.")
+    }
   }
 
   if (!is.null(endyear)) {
@@ -119,8 +134,6 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
     }
   }
 
-
-
   if (survey == "acs1") {
     message(sprintf("Getting data from the %s 1-year ACS", year))
   } else if (survey == "acs3") {
@@ -141,21 +154,8 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
   }
 
-
   if (geography == "block") {
     stop("Block data are not available in the ACS. Use `get_decennial()` to access block data from the 2010 Census.", call. = FALSE)
-  }
-
-  if (survey == "acs3") {
-    if (year > 2013) {
-      stop("The three-year ACS ended in 2013. For newer data, use the 1-year or 5-year ACS.", call. = FALSE)
-    } else {
-      message("The three-year ACS provides data for geographies with populations of 20,000 and greater.")
-    }
-  }
-
-  if (survey == "acs1") {
-    message("The one-year ACS provides data for geographies with populations of 65,000 and greater.")
   }
 
   cache <- getOption("tigris_use_cache", FALSE)

--- a/R/census.R
+++ b/R/census.R
@@ -86,10 +86,6 @@ get_decennial <- function(geography, variables = NULL, table = NULL, cache_table
     stop("The 1990 decennial Census endpoint has been removed by the Census Bureau. We will support 1990 data again when the endpoint is updated; in the meantime, we recommend using NHGIS (https://nhgis.org) and the ipumsr R package.", call. = FALSE)
   }
 
-  if (year == 2000 && sumfile == "sf3") {
-    stop("The 2000 decennial Census SF3 endpoint has been removed by the Census Bureau. We will support this data again when the endpoint is updated; in the meantime, we recommend using NHGIS (https://nhgis.org) and the ipumsr R package.", call. = FALSE)
-  }
-
   if (is.null(variables) && is.null(table)) {
     stop("Either a vector of variables or an table must be specified.", call. = FALSE)
   }

--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -1,11 +1,14 @@
 #' Load variables from a decennial Census or American Community Survey dataset to search in R
 #'
-#' @param year The year for which you are requesting variables.  Either the year of the decennial Census,
-#'             or the endyear for a 5-year ACS sample.
-#' @param dataset One of "sf1", "sf3", "acs1", "acs3", "acs5", "acs1/profile", "acs3/profile, "acs5/profile",
-#'                "acs1/subject", "acs3/subject", or "acs5/subject".
-#' @param cache Whether you would like to cache the dataset for future access, or load the dataset
-#'              from an existing cache. Defaults to FALSE.
+#' @param year The year for which you are requesting variables. Either the year
+#'   or endyear of the decennial Census or ACS sample. 5-year ACS data is
+#'   available from 2009 through 2018. 1-year ACS data is available from 2005
+#'   through 2019.
+#' @param dataset One of "sf1", "sf3", "acs1", "acs3", "acs5", "acs1/profile",
+#'   "acs3/profile, "acs5/profile", "acs1/subject", "acs3/subject", or
+#'   "acs5/subject".
+#' @param cache Whether you would like to cache the dataset for future access,
+#'   or load the dataset from an existing cache. Defaults to FALSE.
 #'
 #' @return A tibble of variables from the requested dataset.
 #' @examples \dontrun{
@@ -13,23 +16,27 @@
 #' View(v15)
 #' }
 #' @export
+#'
 load_variables <- function(year, dataset, cache = FALSE) {
-
-  if (dataset == "sf3" && year == 2000) {
-    stop("The 2000 SF3 endpoint has been removed by the Census Bureau. We will support this data again when the endpoint is updated; in the meantime, we recommend using NHGIS (https://nhgis.org) and the ipumsr R package.")
-  }
 
   if (year == 1990) {
     stop("The 1990 decennial Census endpoint has been removed by the Census Bureau. We will support 1990 data again when the endpoint is updated; in the meantime, we recommend using NHGIS (https://nhgis.org) and the ipumsr R package.")
   }
 
-  if (dataset=="acs3") {
-    if (year > 2013 || year < 2012)
-      stop("The current acs3 survey contains data from 2012-2013. Please select a different year.")
-  }
-
   if (dataset == "sf3" && year > 2001) {
     stop("Summary File 3 was not released in 2010. Use tables from the American Community Survey via get_acs() instead.", call. = FALSE)
+  }
+
+   if (str_detect(dataset, "acs5") && year < 2009) {
+    stop("5-year ACS support in tidycensus begins with the 2005-2009 5-year ACS. Consider using decennial Census data instead.", call. = FALSE)
+  }
+
+  if (str_detect(dataset, "acs1") && year < 2005) {
+      stop("1-year ACS support in tidycensus begins with the 2005 1-year ACS. Consider using decennial Census data instead.", call. = FALSE)
+  }
+
+  if (str_detect(dataset, "acs3") && (year < 2007 || year > 2013)) {
+      stop("3-year ACS support in tidycensus begins with the 2005-2007 3-year ACS and ends with the 2011-2013 3-year ACS. For newer data, use the 1-year or 5-year ACS.", call. = FALSE)
   }
 
   rds <- paste0(dataset, "_", year, ".rds")
@@ -38,77 +45,55 @@ load_variables <- function(year, dataset, cache = FALSE) {
     rds <- gsub("/", "_", rds)
   }
 
-  if (year > 2008 && (grepl("acs1", dataset) || grepl("acs5", dataset)) || grepl("acsse", dataset)) {
+  var_type <- NULL
+
+  if (str_detect(dataset, "/")) {
+    split <- str_split(dataset, "/")[[1]]
+    dataset <- split[1]
+    var_type <- split[2]
+  }
+
+  if (dataset %in% c("sf1", "sf3")) {
+    dataset <- paste0("dec/", dataset)
+  }
+
+  if (dataset %in% c("acs1", "acs3", "acs5")) {
     dataset <- paste0("acs/", dataset)
   }
 
-  get_dataset <- function(d) {
+  if (!is.null(var_type)) {
+    dataset <- paste0(dataset, "/", var_type)
+  }
 
-    # Account for URL change for 2010 decennial Census
-    if (year %in% c(2000, 2010) && dataset == "sf1") {
-      d <- paste0("dec/", d)
-    }
+  get_dataset <- function(d, year) {
 
     set <- paste(year, d, sep = "/")
 
-    # If ACS, use JSON parsing to speed things up
-    if (grepl("acs[135]|acsse", d)) {
+    url <- paste("https://api.census.gov/data",
+                 set,
+                 "variables.json", sep = "/")
 
-      url <- paste("https://api.census.gov/data",
-                   set,
-                   "variables.json", sep = "/")
+    dat <- GET(url) %>%
+      content(as = "text") %>%
+      fromJSON() %>%
+      modify_depth(2, function(x) {
+        x$validValues <- NULL
+        x
+      }) %>%
+      flatten_df(.id = "name") %>%
+      arrange(name)
 
-      dat <- GET(url) %>%
-        content(as = "text") %>%
-        fromJSON() %>%
-        modify_depth(2, function(x) {
-          x$validValues <- NULL
-          x
-        }) %>%
-        flatten_df(.id = "name") %>%
-        arrange(name)
+    out <- dat[,1:3]
 
-      out <- dat[,1:3]
+    names(out) <- tolower(names(out))
 
-      names(out) <- tolower(names(out))
+    out1 <- out[grepl("^B[0-9]|^C[0-9]|^DP[0-9]|^S[0-9]|^P[0-9]|^H[0-9]|^K[0-9]", out$name), ]
 
-      out1 <- out[grepl("^B[0-9]|^C[0-9]|^DP[0-9]|^S[0-9]|^P[0-9]|^H[0-9]|^K[0-9]", out$name), ]
+    out1$name <- str_replace(out1$name, "E$|M$", "")
 
-      out1$name <- str_replace(out1$name, "E$|M$", "")
+    out2 <- out1[!grepl("Margin Of Error|Margin of Error", out1$label), ]
 
-      out2 <- out1[!grepl("Margin Of Error|Margin of Error", out1$label), ]
-
-      return(as_tibble(out2))
-    # Otherwise use HTML scraping as JSON is not available for decennial Census
-    } else {
-
-      url <- paste("http://api.census.gov/data",
-                   set,
-                   "variables.html", sep = "/")
-
-      dat <- url %>%
-        read_html() %>%
-        html_nodes("table") %>%
-        html_table(fill = TRUE)
-
-      out <- dat[[1]]
-
-      out <- out[-1,]
-
-      out <- out[,1:3]
-
-      names(out) <- tolower(names(out))
-
-      out1 <- out[grepl("^P.*|^H.*", out$name), ]
-
-      out1$name <- str_replace(out1$name, "E$|M$", "")
-
-      out2 <- out1[!grepl("Margin Of Error|Margin of Error", out1$label), ]
-
-      return(as_tibble(out2))
-
-    }
-
+    return(as_tibble(out2))
   }
 
   if (cache) {
@@ -128,14 +113,11 @@ load_variables <- function(year, dataset, cache = FALSE) {
 
           # Check if an erroring variable is in the file
           if ("H00010001" %in% out$name) {
-            df <- get_dataset(dataset)
+            df <- get_dataset(dataset, year)
             write_rds(df, file_loc)
             return(df)
-
           }
-
         }
-
 
         out1 <- out[grepl("^B[0-9]|^C[0-9]|^DP[0-9]|^S[0-9]|^P[0-9]|^H[0-9]|^K[0-9]", out$name), ]
 
@@ -143,14 +125,14 @@ load_variables <- function(year, dataset, cache = FALSE) {
 
         out2 <- out1[!grepl("Margin Of Error|Margin of Error", out1$label), ]
         return(out2)
+
       } else {
-        df <- get_dataset(dataset)
+        df <- get_dataset(dataset, year)
         write_rds(df, file_loc)
         return(df)
       }
     }
   } else {
-    return(get_dataset(dataset))
+    get_dataset(dataset, year)
   }
 }
-

--- a/man/get_acs.Rd
+++ b/man/get_acs.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/acs.R
 \name{get_acs}
 \alias{get_acs}
-\title{Obtain data and feature geometry for the five-year American Community Survey}
+\title{Obtain data and feature geometry for the American Community Survey}
 \usage{
 get_acs(
   geography,
@@ -30,70 +30,70 @@ get_acs(
 \item{geography}{The geography of your data.}
 
 \item{variables}{Character string or vector of character strings of variable
-IDs. tidycensus automatically returns the estimate and the
-margin of error associated with the variable.}
+IDs. tidycensus automatically returns the estimate and the margin of error
+associated with the variable.}
 
-\item{table}{The ACS table for which you would like to request all variables. Uses
-lookup tables to identify the variables; performs faster when variable
-table already exists through \code{load_variables(cache = TRUE)}.
-Only one table may be requested per call.}
+\item{table}{The ACS table for which you would like to request all
+variables. Uses lookup tables to identify the variables; performs faster
+when variable table already exists through \code{load_variables(cache =
+TRUE)}. Only one table may be requested per call.}
 
-\item{cache_table}{Whether or not to cache table names for faster future access.
-Defaults to FALSE; if TRUE, only needs to be called once per
+\item{cache_table}{Whether or not to cache table names for faster future
+access. Defaults to FALSE; if TRUE, only needs to be called once per
 dataset.  If variables dataset is already cached via the
 \code{load_variables} function, this can be bypassed.}
 
-\item{year}{The year, or endyear, of the ACS sample. 2009 through 2018 are
-available. Defaults to 2018.}
+\item{year}{The year, or endyear, of the ACS sample. 5-year ACS data is
+available from 2009 through 2018. 1-year ACS data is available from 2005
+through 2019. Defaults to 2018.}
 
 \item{endyear}{Deprecated and will be removed in a future release.}
 
 \item{output}{One of "tidy" (the default) in which each row represents an
-enumeration unit-variable combination, or "wide" in which each
-row represents an enumeration unit and the variables are in the
-columns.}
+enumeration unit-variable combination, or "wide" in which each row
+represents an enumeration unit and the variables are in the columns.}
 
-\item{state}{An optional vector of states for which you are requesting data. State
-names, postal codes, and FIPS codes are accepted.
-Defaults to NULL.}
+\item{state}{An optional vector of states for which you are requesting data.
+State names, postal codes, and FIPS codes are accepted. Defaults to NULL.}
 
 \item{county}{The county for which you are requesting data. County names and
-FIPS codes are accepted. Must be combined with a value supplied
-to `state`.  Defaults to NULL.}
+FIPS codes are accepted. Must be combined with a value supplied to `state`.
+Defaults to NULL.}
 
-\item{zcta}{The zip code tabulation area(s) for which you are requesting data.
-Specify a single value or a vector of values to get data for more
-than one ZCTA. Numeric or character ZCTA GEOIDs are accepted.
-When specifying ZCTAs, geography must be set to `"zcta"` and
-`state` and `county` must be `NULL`. Defaults to NULL.}
+\item{zcta}{The zip code tabulation area(s) for which you are requesting
+data. Specify a single value or a vector of values to get data for more
+than one ZCTA. Numeric or character ZCTA GEOIDs are accepted. When
+specifying ZCTAs, geography must be set to `"zcta"` and `state` and
+`county` must be `NULL`. Defaults to NULL.}
 
 \item{geometry}{if FALSE (the default), return a regular tibble of ACS data.
-if TRUE, uses the tigris package to return an sf tibble
-with simple feature geometry in the `geometry` column.}
+if TRUE, uses the tigris package to return an sf tibble with simple feature
+geometry in the `geometry` column.}
 
 \item{keep_geo_vars}{if TRUE, keeps all the variables from the Census
 shapefile obtained by tigris.  Defaults to FALSE.}
 
-\item{shift_geo}{if TRUE, returns geometry with Alaska and Hawaii shifted for thematic mapping of the entire US.
-Geometry was originally obtained from the albersusa R package.}
+\item{shift_geo}{if TRUE, returns geometry with Alaska and Hawaii shifted for
+thematic mapping of the entire US. Geometry was originally obtained from
+the albersusa R package.}
 
-\item{summary_var}{Character string of a "summary variable" from the ACS
-to be included
-in your output. Usually a variable (e.g. total population)
-that you'll want to use as a denominator or comparison.}
+\item{summary_var}{Character string of a "summary variable" from the ACS to
+be included in your output. Usually a variable (e.g. total population) that
+you'll want to use as a denominator or comparison.}
 
-\item{key}{Your Census API key.
-Obtain one at \url{http://api.census.gov/data/key_signup.html}}
+\item{key}{Your Census API key. Obtain one at
+\url{http://api.census.gov/data/key_signup.html}}
 
-\item{moe_level}{The confidence level of the returned margin of error.  One of 90 (the default), 95, or 99.}
+\item{moe_level}{The confidence level of the returned margin of error.  One
+of 90 (the default), 95, or 99.}
 
-\item{survey}{The ACS contains one-year, three-year, and five-year surveys expressed as "acs1", "acs3", and "acs5".
-The default selection is "acs5."}
+\item{survey}{The ACS contains one-year, three-year, and five-year surveys
+expressed as "acs1", "acs3", and "acs5". The default selection is "acs5."}
 
-\item{show_call}{if TRUE, display call made to Census API. This can be very useful
-in debugging and determining if error messages returned are
-due to tidycensus or the Census API. Copy to the API call into
-a browser and see what is returned by the API directly. Defaults to FALSE.}
+\item{show_call}{if TRUE, display call made to Census API. This can be very
+useful in debugging and determining if error messages returned are due to
+tidycensus or the Census API. Copy to the API call into a browser and see
+what is returned by the API directly. Defaults to FALSE.}
 
 \item{...}{Other keyword arguments}
 }
@@ -101,7 +101,7 @@ a browser and see what is returned by the API directly. Defaults to FALSE.}
 A tibble or sf tibble of ACS data
 }
 \description{
-Obtain data and feature geometry for the five-year American Community Survey
+Obtain data and feature geometry for the American Community Survey
 }
 \examples{
 \dontrun{

--- a/man/load_variables.Rd
+++ b/man/load_variables.Rd
@@ -7,14 +7,17 @@
 load_variables(year, dataset, cache = FALSE)
 }
 \arguments{
-\item{year}{The year for which you are requesting variables.  Either the year of the decennial Census,
-or the endyear for a 5-year ACS sample.}
+\item{year}{The year for which you are requesting variables. Either the year
+or endyear of the decennial Census or ACS sample. 5-year ACS data is
+available from 2009 through 2018. 1-year ACS data is available from 2005
+through 2019.}
 
-\item{dataset}{One of "sf1", "sf3", "acs1", "acs3", "acs5", "acs1/profile", "acs3/profile, "acs5/profile",
-"acs1/subject", "acs3/subject", or "acs5/subject".}
+\item{dataset}{One of "sf1", "sf3", "acs1", "acs3", "acs5", "acs1/profile",
+"acs3/profile, "acs5/profile", "acs1/subject", "acs3/subject", or
+"acs5/subject".}
 
-\item{cache}{Whether you would like to cache the dataset for future access, or load the dataset
-from an existing cache. Defaults to FALSE.}
+\item{cache}{Whether you would like to cache the dataset for future access,
+or load the dataset from an existing cache. Defaults to FALSE.}
 }
 \value{
 A tibble of variables from the requested dataset.


### PR DESCRIPTION
A few small changes here:

- Re: #329, this allows `get_acs()` to access 1-year data beginning in 2005 and 3-year beginning in 2007. @walkerke am I remembering that data from these years used to be in a different format in the API? I did a bit of informal testing and everything seems to be working on my end.

- Re: #293, 2000 SF3 data is [back up on the API](https://uscensusbureau.slack.com/archives/C6DGLC05B/p1607100621206000), so I simply removed the stop logic in `get_decennial()`

- Because I added support for earlier datasets in `get_acs()`, I took a look at `load_variables()` and simplified the logic because it appears that all endpoints now have variables available as JSON.

@walkerke I'd appreciate a bit of testing on these changes when you have a chance...I did some informal checks, but nothing super-through. 