### PR TITLE
Improved error handling and documentation for get_estimates()

### DIFF
--- a/R/estimates.R
+++ b/R/estimates.R
@@ -3,8 +3,8 @@
 #' @param geography The geography of your data.
 #' @param product The data product (optional). \code{"population"}, \code{"components"}
 #'                \code{"housing"}, and \code{"characteristics"} are supported.
-#' @param variables A character string or vector of requested variables to get
-#'                  from the population, components, or housing API.
+#' @param variables A character string or vector of character strings of requested variables
+#'                  to get from either the population, components, or housing API.
 #' @param breakdown The population breakdown used when \code{product = "characteristics"}.
 #'                  Acceptable values are \code{"AGEGROUP"}, \code{"RACE"}, \code{"SEX"}, and
 #'                  \code{"HISP"}, for Hispanic/Not Hispanic.  These values can be combined in

--- a/R/estimates.R
+++ b/R/estimates.R
@@ -12,7 +12,7 @@
 #'                  combinations of these breakdowns.
 #' @param breakdown_labels Whether or not to label breakdown elements returned when
 #'                         \code{product = "characteristics"}. Defaults to FALSE.
-#' @param year The data year (defaults to 2018)
+#' @param year The data year (defaults to 2019)
 #' @param state The state for which you are requesting data. State
 #'              names, postal codes, and FIPS codes are accepted.
 #'              Defaults to NULL.
@@ -23,7 +23,7 @@
 #'                    of 2010. The returned column is either "DATE", representing a particular estimate date, or "PERIOD",
 #'                    representing a time period (e.g. births between 2016 and 2017), and contains integers representing
 #'                    those values.  Integer to date or period mapping is available at
-#'                    \url{https://www.census.gov/data/developers/data-sets/popest-popproj/popest/popest-vars/2018.html}.
+#'                    \url{https://www.census.gov/data/developers/data-sets/popest-popproj/popest/popest-vars/2019.html}.
 #' @param output One of "tidy" (the default) in which each row represents an
 #'               enumeration unit-variable combination, or "wide" in which each
 #'               row represents an enumeration unit and the variables are in the

--- a/R/estimates.R
+++ b/R/estimates.R
@@ -3,8 +3,8 @@
 #' @param geography The geography of your data.
 #' @param product The data product (optional). \code{"population"}, \code{"components"}
 #'                \code{"housing"}, and \code{"characteristics"} are supported.
-#' @param variables A character string of requested variables to get specific
-#'                  variables from the population, components, and housing APIs.
+#' @param variables A character string or vector of requested variables to get
+#'                  from the population, components, or housing API.
 #' @param breakdown The population breakdown used when \code{product = "characteristics"}.
 #'                  Acceptable values are \code{"AGEGROUP"}, \code{"RACE"}, \code{"SEX"}, and
 #'                  \code{"HISP"}, for Hispanic/Not Hispanic.  These values can be combined in

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -486,7 +486,7 @@ load_data_estimates <- function(geography, product = NULL, variables = NULL, key
 
   for_area <- paste0(geography, ":*")
 
-  if (year == 2019) {
+  if (year >= 2019) {
     geo_name <- "NAME"
   } else {
     geo_name <- "GEONAME"
@@ -494,7 +494,7 @@ load_data_estimates <- function(geography, product = NULL, variables = NULL, key
 
   if (is.null(variables)) {
     if (is.null(product)) {
-      stop("Either a product or a vector of variables is required.", call. = FALSE)
+      stop("Either a product or a vector of variables (from a single product) is required.", call. = FALSE)
     } else {
       if (product == "population") {
         vars_to_get <- paste0(geo_name, ",POP,DENSITY")
@@ -514,10 +514,17 @@ load_data_estimates <- function(geography, product = NULL, variables = NULL, key
     } else {
       if (all(variables %in% c("POP", "DENSITY"))) {
         product <- "population"
-      } else if (all(variables %in% c("BIRTHS", "DEATHS","DOMESTICMIG","INTERNATIONALMIG","NATURALINC","NETMIG","RBIRTH","RDEATH","RDOMESTICMIG","RINTERNATIONALMIG","RNATURALINC","RNETMIG"))) {
+      } else if (all(variables %in% c("BIRTHS", "DEATHS", "DOMESTICMIG", "INTERNATIONALMIG", "NATURALINC", "NETMIG", "RBIRTH", "RDEATH", "RDOMESTICMIG", "RINTERNATIONALMIG", "RNATURALINC", "RNETMIG"))) {
         product <- "components"
-      } else if (variables == "HUEST") {
+      } else if (all(variables %in% c("HUEST"))) {
         product <- "housing"
+      } else {
+        stop(
+          paste('Variables must be a subset of only one of the following sets of valid variables:',
+                'for population estimates, c("POP", "DENSITY");',
+                'for housing unit estimates, c("HUEST");',
+                'and for components of change estimates, c("BIRTHS", "DEATHS", "DOMESTICMIG", "INTERNATIONALMIG", "NATURALINC", "NETMIG", "RBIRTH", "RDEATH", "RDOMESTICMIG", "RINTERNATIONALMIG", "RNATURALINC", "RNETMIG").'),
+          call. = FALSE)
       }
     }
     vars_to_get <- paste0(geo_name, ",", paste0(variables, collapse = ","))

--- a/man/get_estimates.Rd
+++ b/man/get_estimates.Rd
@@ -29,8 +29,8 @@ get_estimates(
 \item{product}{The data product (optional). \code{"population"}, \code{"components"}
 \code{"housing"}, and \code{"characteristics"} are supported.}
 
-\item{variables}{A character string or vector of requested variables to get
-from the population, components, or housing API.}
+\item{variables}{A character string or vector of character strings of requested variables
+to get from either the population, components, or housing API.}
 
 \item{breakdown}{The population breakdown used when \code{product = "characteristics"}.
 Acceptable values are \code{"AGEGROUP"}, \code{"RACE"}, \code{"SEX"}, and

--- a/man/get_estimates.Rd
+++ b/man/get_estimates.Rd
@@ -41,7 +41,7 @@ combinations of these breakdowns.}
 \item{breakdown_labels}{Whether or not to label breakdown elements returned when
 \code{product = "characteristics"}. Defaults to FALSE.}
 
-\item{year}{The data year (defaults to 2018)}
+\item{year}{The data year (defaults to 2019)}
 
 \item{state}{The state for which you are requesting data. State
 names, postal codes, and FIPS codes are accepted.
@@ -55,7 +55,7 @@ to `state`.  Defaults to NULL.}
 of 2010. The returned column is either "DATE", representing a particular estimate date, or "PERIOD",
 representing a time period (e.g. births between 2016 and 2017), and contains integers representing
 those values.  Integer to date or period mapping is available at
-\url{https://www.census.gov/data/developers/data-sets/popest-popproj/popest/popest-vars/2018.html}.}
+\url{https://www.census.gov/data/developers/data-sets/popest-popproj/popest/popest-vars/2019.html}.}
 
 \item{output}{One of "tidy" (the default) in which each row represents an
 enumeration unit-variable combination, or "wide" in which each

--- a/man/get_estimates.Rd
+++ b/man/get_estimates.Rd
@@ -29,8 +29,8 @@ get_estimates(
 \item{product}{The data product (optional). \code{"population"}, \code{"components"}
 \code{"housing"}, and \code{"characteristics"} are supported.}
 
-\item{variables}{A character string of requested variables to get specific
-variables from the population, components, and housing APIs.}
+\item{variables}{A character string or vector of requested variables to get
+from the population, components, or housing API.}
 
 \item{breakdown}{The population breakdown used when \code{product = "characteristics"}.
 Acceptable values are \code{"AGEGROUP"}, \code{"RACE"}, \code{"SEX"}, and


### PR DESCRIPTION
I was recently attempting to use `get_estimates()` for the first time, and was having a hard time finding the cause of some error messages I was receiving. I'm submitting this pull request to make the error messages a little bit more informative in these particular use cases.

### 1st case: mixing variables from multiple products

I was initially hopeful that I could use the `variables` parameter to specify variables from multiple products, e.g. `variables=c("POP","HUEST")`. Nothing in the documentation suggested this was not allowed (although I realize it would require the results of multiple API calls to be combined). The parameter description says "A character string of requested variables to get specific variables from the population, components, **and** housing APIs" (emphasis mine). 

I have updated the parameter description to read "A character string or vector of character strings of requested variables to get from either the population, components, or housing API." I also modified the error handling code to be more informative, as it was not explicitly caught before.

Current error message when attempting this:
```
> get_estimates("county", state="IL", county="031", variables=c("POP", "HUEST"))
Using FIPS code '17' for state 'IL'
Error in parse_url(url) : length(url) == 1 is not TRUE
In addition: Warning message:
In if (variables == "HUEST") { :
  the condition has length > 1 and only the first element will be used
```

Updated error message:
```
> get_estimates("county", state="IL", county="031", variables=c("POP", "HUEST"))
 Error: Variables must be a subset of only one of the following sets of valid variables: for
 population estimates, c("POP", "DENSITY"); for housing unit estimates, c("HUEST"); and for
 components of change estimates, c("BIRTHS", "DEATHS", "DOMESTICMIG", "INTERNATIONALMIG",
 "NATURALINC", "NETMIG", "RBIRTH", "RDEATH", "RDOMESTICMIG", "RINTERNATIONALMIG",
 "RNATURALINC", "RNETMIG").
```

### 2nd case: specifying unsupported variables
Related to the 1st case, it is also not clear which specific variables can be requested in `variables`. I assumed any variable listed in the Census Bureau's API docs would be accepted, but that is not the case. For example, I wanted to get "SUMLEVEL" with my population estimates, but there was no indication this variable was not supported.

Current and updated error messages for this case are identical to those in the 1st case.