### PR TITLE
Fix get_pums bug when state = "all"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     person(given = "Kyle", family = "Walker", email="kyle@walker-data.com", role=c("aut", "cre")),
     person(given = "Matt", family = "Herman", email = "mfherman@gmail.com", role = "aut"),
     person(given = "Kris", family = "Eberwein", email = "eberwein@knights.ucf.edu", role = "ctb"))
-Date: 2021-04-09
+Date: 2021-04-23
 URL: https://github.com/walkerke/tidycensus
 BugReports: https://github.com/walkerke/tidycensus/issues
 Description: An integrated R interface to the decennial US Census and American Community Survey APIs and

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -789,7 +789,12 @@ load_data_pums <- function(variables, state, puma, key, year, survey,
     var <- paste0(variables, collapse = ",")
 
     vars_to_get <- paste0("SERIALNO,SPORDER,WGTP,PWGTP,", var)
-
+    
+    # If geo is NULL, state should be added back in here
+    if (is.null(geo)) {
+      vars_to_get <- paste0(vars_to_get, ",ST")
+    }
+    
     query <- list(get = vars_to_get,
                   ucgid = geo,
                   key = key)


### PR DESCRIPTION
Re: #365 Fix bug where ST was not included when state = "all" in get_pums causing an error in pivot_longer step