### PR TITLE
Fixed typo and updated example

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -75,7 +75,7 @@
 #' vt %>%
 #' mutate(NAME = gsub(" County, Vermont", "", NAME)) %>%
 #'  ggplot(aes(x = estimate, y = reorder(NAME, estimate))) +
-#'   geom_errorbarh(aes(xmin = estimate - moe, xmax = estimate + moe)) +
+#'   geom_errorbar(aes(xmin = estimate - moe, xmax = estimate + moe), width = 0.3, size = 0.5) +
 #'   geom_point(color = "red", size = 3) +
 #'   labs(title = "Household income by county in Vermont",
 #'        subtitle = "2015-2019 American Community Survey",


### PR DESCRIPTION
typo in example (`geom_errorbarh`). Changed to `geom_errorbar`, which also allows for passing additional values, parameters and constraints (e.g., `width` and `size` as I've added by way of example).