### PR TITLE
Add parentheses to mentions of census_api_key()

### DIFF
--- a/R/acs.R
+++ b/R/acs.R
@@ -155,7 +155,7 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
   } else if (is.null(key)) {
 
-    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key` function to use it throughout your tidycensus session.')
+    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key()` function to use it throughout your tidycensus session.')
 
   }
 

--- a/R/census.R
+++ b/R/census.R
@@ -98,7 +98,7 @@ get_decennial <- function(geography, variables = NULL, table = NULL, cache_table
 
   } else if (is.null(key)) {
 
-    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key` function to use it throughout your tidycensus session.')
+    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key()` function to use it throughout your tidycensus session.')
 
   }
 

--- a/R/estimates.R
+++ b/R/estimates.R
@@ -69,7 +69,7 @@ get_estimates <- function(geography, product = NULL, variables = NULL,
 
   } else if (is.null(key)) {
 
-    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key` function to use it throughout your tidycensus session.')
+    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key()` function to use it throughout your tidycensus session.')
 
   }
 

--- a/R/flows.R
+++ b/R/flows.R
@@ -91,7 +91,7 @@ get_flows <- function(geography, variables = NULL, breakdown = NULL,
   if (Sys.getenv('CENSUS_API_KEY') != '') {
     key <- Sys.getenv('CENSUS_API_KEY')
   } else if (is.null(key)) {
-    stop('A Census API key is required. Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key` function to use it throughout your tidycensus session.')
+    stop('A Census API key is required. Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key()` function to use it throughout your tidycensus session.')
   }
 
   if (geography %in% c("cbsa", "msa", "metropolitan statistical area")) {

--- a/R/pums.R
+++ b/R/pums.R
@@ -71,7 +71,7 @@ get_pums <- function(variables = NULL,
 
   } else if (is.null(key)) {
 
-    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key` function to use it throughout your tidycensus session.')
+    stop('A Census API key is required.  Obtain one at http://api.census.gov/data/key_signup.html, and then supply the key to the `census_api_key()` function to use it throughout your tidycensus session.')
 
   }
 


### PR DESCRIPTION
Thanks putting in the work for this wonderful package. This PR adds parentheses to warning mentions of the function `census_api_key()`. Using parentheses to distinguish functions from other R objects appears to be a tidy convention. See this example involving `create_package()` https://r-pkgs.org/whole-game.html#create_package 