### PR TITLE
Correctly return vacant housing units in `get_pums()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     person(given = "Kyle", family = "Walker", email="kyle@walker-data.com", role=c("aut", "cre")),
     person(given = "Matt", family = "Herman", email = "mfherman@gmail.com", role = "aut"),
     person(given = "Kris", family = "Eberwein", email = "eberwein@knights.ucf.edu", role = "ctb"))
-Date: 2022-04-01
+Date: 2022-04-02
 URL: https://walker-data.com/tidycensus/
 BugReports: https://github.com/walkerke/tidycensus/issues
 Description: An integrated R interface to several United States Census Bureau 

--- a/R/pums.R
+++ b/R/pums.R
@@ -84,13 +84,13 @@ get_pums <- function(variables = NULL,
     stop("You must specify a state by name, postal code, or FIPS code. To request data for the entire United States, specify `state = 'all'`.", call. = FALSE)
   }
 
+  if (return_vacant) {
+    variables <- c(variables, "VACS")
+  }
+
   if ("VACS" %in% variables) {
     message("You have requested information on vacant units; setting `return_vacant` to TRUE")
     return_vacant <- TRUE
-  }
-
-  if (return_vacant) {
-    variables <- c(variables, "VACS")
   }
 
 

--- a/R/pums.R
+++ b/R/pums.R
@@ -84,8 +84,9 @@ get_pums <- function(variables = NULL,
     stop("You must specify a state by name, postal code, or FIPS code. To request data for the entire United States, specify `state = 'all'`.", call. = FALSE)
   }
 
-  if ("VACP" %in% variables) {
+  if ("VACS" %in% variables) {
     message("You have requested information on vacant units; setting `return_vacant` to TRUE")
+    return_vacant <- TRUE
   }
 
   if (return_vacant) {
@@ -257,12 +258,16 @@ get_pums <- function(variables = NULL,
     vacant_filter <- list(VACS = 1:7)
 
     vacant_variables <- variables
+    vacant_variables <- vacant_variables[vacant_variables != "VACS"]
 
     # Handle replicate weights appropriately
-    if (rep_weights == "both") {
-      # remove the person weight variables
-      vacant_variables <- vacant_variables[!vacant_variables %in% person_weight_variables]
+    if (!is.null(rep_weights)) {
+      if (rep_weights == "both") {
+        # remove the person weight variables
+        vacant_variables <- vacant_variables[!vacant_variables %in% person_weight_variables]
+      }
     }
+
 
     if (length(vacant_variables) > 45) {
       l <- split(vacant_variables, ceiling(seq_along(variables) / 45))

--- a/R/pums.R
+++ b/R/pums.R
@@ -24,6 +24,11 @@
 #' @param recode If TRUE, recodes variable values using Census data dictionary
 #'   and creates a new \code{*_label} column for each variable that is recoded.
 #'   Available for 2017 - 2020 data. Defaults to FALSE.
+#' @param return_vacant If TRUE, makes a separate request to the Census API to
+#'   retrieve microdata for vacant housing units, which are handled differently
+#'   in the API as they do not have person-level characteristics.  All person-level
+#'   columns in the returned dataset will be populated with NA for vacant housing units.
+#'   Defaults to FALSE.
 #' @param show_call If TRUE, display call made to Census API. This can be very
 #'   useful in debugging and determining if error messages returned are due to
 #'   tidycensus or the Census API. Copy to the API call into a browser and see
@@ -50,6 +55,7 @@ get_pums <- function(variables = NULL,
                      variables_filter = NULL,
                      rep_weights = NULL,
                      recode = FALSE,
+                     return_vacant = FALSE,
                      show_call = FALSE,
                      key = NULL) {
 
@@ -76,6 +82,14 @@ get_pums <- function(variables = NULL,
 
   if (is.null(state)) {
     stop("You must specify a state by name, postal code, or FIPS code. To request data for the entire United States, specify `state = 'all'`.", call. = FALSE)
+  }
+
+  if ("VACP" %in% variables) {
+    message("You have requested information on vacant units; setting `return_vacant` to TRUE")
+  }
+
+  if (return_vacant) {
+    variables <- c(variables, "VACS")
   }
 
 
@@ -233,6 +247,106 @@ get_pums <- function(variables = NULL,
                                 recode = recode,
                                 show_call = show_call,
                                 key = key)
+  }
+
+  # Handle vacant units if requested
+  # Basically, a separate request needs to be made to the API that removes any person-level
+  # variables, handled with the same logic as above
+  if (return_vacant) {
+
+    vacant_filter <- list(VACS = 1:7)
+
+    vacant_variables <- variables
+
+    # Handle replicate weights appropriately
+    if (rep_weights == "both") {
+      # remove the person weight variables
+      vacant_variables <- vacant_variables[!vacant_variables %in% person_weight_variables]
+    }
+
+    if (length(vacant_variables) > 45) {
+      l <- split(vacant_variables, ceiling(seq_along(variables) / 45))
+      vacant_data <- map(l, function(x) {
+
+        load_data_pums_vacant(variables = x,
+                       state = state,
+                       year = year,
+                       puma = puma,
+                       survey = survey,
+                       variables_filter = vacant_filter,
+                       recode = recode,
+                       show_call = show_call,
+                       key = key)
+      })
+
+      # to combine the multiple API calls, we need to join using the repeated
+      # variables so they don't get duplicated in the final data frame
+      # the repeated variables will depend on how we requested data
+      vacant_join_vars <- c("SERIALNO", "WGTP", "ST")
+
+      if (recode) {
+        if (!is.null(puma)) {
+          vacant_join_vars <- c(join_vars, "ST_label", "PUMA")
+        } else {
+          vacant_join_vars <- c(join_vars, "ST_label")
+        }
+      } else {
+        if (!is.null(puma)) {
+          vacant_join_vars <- c(join_vars, "PUMA")
+        }
+      }
+
+      # Keep here for posterity but not needed for vacant units
+      # if (!is.null(variables_filter)) {
+      #   var_names <- names(variables_filter)
+      #   var_names <- var_names[!var_names == "SPORDER"]
+      #
+      #   if (recode) {
+      #     check_type <- pums_variables %>%
+      #       dplyr::filter(var_code %in% var_names,
+      #                     survey == survey,
+      #                     year == year,
+      #                     data_type == "chr") %>%
+      #       dplyr::distinct(var_code) %>%
+      #       dplyr::pull(var_code)
+      #
+      #     chr_names <- var_names[var_names %in% check_type]
+      #
+      #     if (length(chr_names) > 0) {
+      #       var_labels <- paste0(chr_names, "_label")
+      #
+      #       join_vars <- c(join_vars, var_names, var_labels)
+      #     } else {
+      #       join_vars <- c(join_vars, var_names)
+      #     }
+      #
+      #   } else {
+      #     join_vars <- c(join_vars, var_names)
+      #   }
+      # }
+
+      vacant_data <- reduce(vacant_data, left_join, by = vacant_join_vars)
+
+
+      vacant_data <- select(vacant_data, -contains("WGTP"), everything(), contains("WGTP"))
+    } else {
+      vacant_data <- suppressMessages(load_data_pums_vacant(
+        variables = vacant_variables,
+        state = state,
+        puma = puma,
+        year = year,
+        survey = survey,
+        variables_filter = vacant_filter,
+        recode = recode,
+        show_call = show_call,
+        key = key
+      ))
+    }
+
+
+
+    # Test out the row-bindings first and foremost
+    output_data <- dplyr::bind_rows(pums_data, vacant_data)
   }
 
   return(pums_data)

--- a/R/pums.R
+++ b/R/pums.R
@@ -322,13 +322,13 @@ get_pums <- function(variables = NULL,
           if (length(chr_names) > 0) {
             var_labels <- paste0(chr_names, "_label")
 
-            join_vars <- c(join_vars, var_names, var_labels)
+            vacant_join_vars <- c(vacant_join_vars, var_names, var_labels)
           } else {
-            join_vars <- c(join_vars, var_names)
+            vacant_join_vars <- c(vacant_join_vars, var_names)
           }
 
         } else {
-          join_vars <- c(join_vars, var_names)
+          vacant_join_vars <- c(vacant_join_vars, var_names)
         }
       }
 

--- a/R/pums.R
+++ b/R/pums.R
@@ -347,9 +347,11 @@ get_pums <- function(variables = NULL,
 
     # Test out the row-bindings first and foremost
     output_data <- dplyr::bind_rows(pums_data, vacant_data)
+  } else {
+    output_data <- pums_data
   }
 
-  return(pums_data)
+  return(output_data)
 }
 
 

--- a/R/pums.R
+++ b/R/pums.R
@@ -270,7 +270,7 @@ get_pums <- function(variables = NULL,
 
 
     if (length(vacant_variables) > 45) {
-      l <- split(vacant_variables, ceiling(seq_along(variables) / 45))
+      l <- split(vacant_variables, ceiling(seq_along(vacant_variables) / 45))
       vacant_data <- map(l, function(x) {
 
         load_data_pums_vacant(variables = x,
@@ -291,44 +291,46 @@ get_pums <- function(variables = NULL,
 
       if (recode) {
         if (!is.null(puma)) {
-          vacant_join_vars <- c(join_vars, "ST_label", "PUMA")
+          vacant_join_vars <- c(vacant_join_vars, "ST_label", "PUMA")
         } else {
-          vacant_join_vars <- c(join_vars, "ST_label")
+          vacant_join_vars <- c(vacant_join_vars, "ST_label")
         }
       } else {
         if (!is.null(puma)) {
-          vacant_join_vars <- c(join_vars, "PUMA")
+          vacant_join_vars <- c(vacant_join_vars, "PUMA")
         }
       }
 
-      # Keep here for posterity but not needed for vacant units
-      # if (!is.null(variables_filter)) {
-      #   var_names <- names(variables_filter)
-      #   var_names <- var_names[!var_names == "SPORDER"]
-      #
-      #   if (recode) {
-      #     check_type <- pums_variables %>%
-      #       dplyr::filter(var_code %in% var_names,
-      #                     survey == survey,
-      #                     year == year,
-      #                     data_type == "chr") %>%
-      #       dplyr::distinct(var_code) %>%
-      #       dplyr::pull(var_code)
-      #
-      #     chr_names <- var_names[var_names %in% check_type]
-      #
-      #     if (length(chr_names) > 0) {
-      #       var_labels <- paste0(chr_names, "_label")
-      #
-      #       join_vars <- c(join_vars, var_names, var_labels)
-      #     } else {
-      #       join_vars <- c(join_vars, var_names)
-      #     }
-      #
-      #   } else {
-      #     join_vars <- c(join_vars, var_names)
-      #   }
-      # }
+      # We need the filter logic to correctly process vacancies
+      # because we are using filters
+      # Repurpose the old code here and refactor later after it works
+
+      if (!is.null(vacant_filter)) {
+        var_names <- names(vacant_filter)
+
+        if (recode) {
+          check_type <- pums_variables %>%
+            dplyr::filter(var_code %in% var_names,
+                          survey == survey,
+                          year == year,
+                          data_type == "chr") %>%
+            dplyr::distinct(var_code) %>%
+            dplyr::pull(var_code)
+
+          chr_names <- var_names[var_names %in% check_type]
+
+          if (length(chr_names) > 0) {
+            var_labels <- paste0(chr_names, "_label")
+
+            join_vars <- c(join_vars, var_names, var_labels)
+          } else {
+            join_vars <- c(join_vars, var_names)
+          }
+
+        } else {
+          join_vars <- c(join_vars, var_names)
+        }
+      }
 
       vacant_data <- reduce(vacant_data, left_join, by = vacant_join_vars)
 

--- a/man/get_pums.Rd
+++ b/man/get_pums.Rd
@@ -13,6 +13,7 @@ get_pums(
   variables_filter = NULL,
   rep_weights = NULL,
   recode = FALSE,
+  return_vacant = FALSE,
   show_call = FALSE,
   key = NULL
 )
@@ -49,6 +50,12 @@ errors; one of \code{"person"}, \code{"housing"}, or \code{"both"}.}
 \item{recode}{If TRUE, recodes variable values using Census data dictionary
 and creates a new \code{*_label} column for each variable that is recoded.
 Available for 2017 - 2020 data. Defaults to FALSE.}
+
+\item{return_vacant}{If TRUE, makes a separate request to the Census API to
+retrieve microdata for vacant housing units, which are handled differently
+in the API as they do not have person-level characteristics.  All person-level
+columns in the returned dataset will be populated with NA for vacant housing units.
+Defaults to FALSE.}
 
 \item{show_call}{If TRUE, display call made to Census API. This can be very
 useful in debugging and determining if error messages returned are due to


### PR DESCRIPTION
See issue #405.  Makes separate calls to the API - one for non-vacant units (which can have person-level characteristics) and one for vacant units (which will disappear from an API call when person-level characteristics are requested) and combines the result.  

cc @mfherman @szimmer if you are interested in putting eyes on this.  