### PR TITLE
more informative error messages in load_variables

### DIFF
--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -18,19 +18,19 @@
 #' }
 #' @export
 #'
-load_variables <- function(year, dataset, cache = FALSE) {
+load_variables <- function(
+  year,
+  dataset = c("sf1", "sf2", "sf3", "sf4", "pl",
+              "as", "gu", "mp", "vi", "acs1", "acs3", "acs5", "acs1/profile",
+              "acs3/profile", "acs5/profile", "acs1/subject", "acs3/subject",
+              "acs5/subject"),
+  cache = FALSE) {
 
   if (length(year) != 1 || !grepl('[0-9]{4}', year)){
     stop("Argument \"year\" must be a single year in format YYYY.")
   }
 
-  allowed_datasets <- c("sf1", "sf2", "sf3", "sf4", "pl",
-                        "as", "gu", "mp", "vi", "acs1", "acs3", "acs5", "acs1/profile",
-                        "acs3/profile", "acs5/profile", "acs1/subject", "acs3/subject",
-                        "acs5/subject")
-  if (length(dataset) != 1 || !(dataset %in% allowed_datasets)) {
-    stop("Argument \"dataset\" must be one (and only one) of: \n", paste0(allowed_datasets, collapse = ", "))
-  }
+  dataset <- match.arg(dataset)
 
   if (year == 2020 && stringr::str_detect(dataset, "acs1")) {
     stop("The 2020 1-year ACS was released as a set of experimental estimates that was not published to the Census API and is in turn not available in tidycensus.", call. = FALSE)

--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -6,7 +6,7 @@
 #'   through 2019.
 #' @param dataset One of "sf1", "sf2", "sf3", "sf4", "pl",
 #'   "as", "gu", "mp", "vi", "acs1", "acs3", "acs5", "acs1/profile",
-#'   "acs3/profile, "acs5/profile", "acs1/subject", "acs3/subject", or
+#'   "acs3/profile", "acs5/profile", "acs1/subject", "acs3/subject", or
 #'   "acs5/subject".
 #' @param cache Whether you would like to cache the dataset for future access,
 #'   or load the dataset from an existing cache. Defaults to FALSE.
@@ -19,6 +19,18 @@
 #' @export
 #'
 load_variables <- function(year, dataset, cache = FALSE) {
+
+  if (length(year) != 1 || !grepl('[0-9]{4}', year)){
+    stop("Argument \"year\" must be a single year in format YYYY.")
+  }
+
+  allowed_datasets <- c("sf1", "sf2", "sf3", "sf4", "pl",
+                        "as", "gu", "mp", "vi", "acs1", "acs3", "acs5", "acs1/profile",
+                        "acs3/profile", "acs5/profile", "acs1/subject", "acs3/subject",
+                        "acs5/subject")
+  if (length(dataset) != 1 || !(dataset %in% allowed_datasets)) {
+    stop("Argument \"dataset\" must be one (and only one) of: \n", paste0(allowed_datasets, collapse = ", "))
+  }
 
   if (year == 2020 && stringr::str_detect(dataset, "acs1")) {
     stop("The 2020 1-year ACS was released as a set of experimental estimates that was not published to the Census API and is in turn not available in tidycensus.", call. = FALSE)
@@ -78,8 +90,13 @@ load_variables <- function(year, dataset, cache = FALSE) {
     url <- paste("https://api.census.gov/data",
                  set,
                  "variables.json", sep = "/")
-
-    dat <- httr::GET(url) %>%
+    resp <- httr::GET(url)
+    if(httr::status_code(resp) == 404L){
+      stop("API endpoint not found. Does this data set exist for the specified year? See https://api.census.gov/data.html for data availability.")
+    }else if(httr::http_status(resp)$category != "Success"){
+      stop(paste("API request failed. Reason:", httr::http_status(resp)$message))
+    }
+    dat <- resp %>%
       httr::content(as = "text") %>%
       jsonlite::fromJSON() %>%
       purrr::modify_depth(2, function(x) {

--- a/man/load_variables.Rd
+++ b/man/load_variables.Rd
@@ -4,7 +4,13 @@
 \alias{load_variables}
 \title{Load variables from a decennial Census or American Community Survey dataset to search in R}
 \usage{
-load_variables(year, dataset, cache = FALSE)
+load_variables(
+  year,
+  dataset = c("sf1", "sf2", "sf3", "sf4", "pl", "as", "gu", "mp", "vi", "acs1", "acs3",
+    "acs5", "acs1/profile", "acs3/profile", "acs5/profile", "acs1/subject",
+    "acs3/subject", "acs5/subject"),
+  cache = FALSE
+)
 }
 \arguments{
 \item{year}{The year for which you are requesting variables. Either the year
@@ -14,7 +20,7 @@ through 2019.}
 
 \item{dataset}{One of "sf1", "sf2", "sf3", "sf4", "pl",
 "as", "gu", "mp", "vi", "acs1", "acs3", "acs5", "acs1/profile",
-"acs3/profile, "acs5/profile", "acs1/subject", "acs3/subject", or
+"acs3/profile", "acs5/profile", "acs1/subject", "acs3/subject", or
 "acs5/subject".}
 
 \item{cache}{Whether you would like to cache the dataset for future access,


### PR DESCRIPTION
This PR makes the error messages thrown by `load_variables` a little more user friendly. 

### Checking Year
An error will now throw if `year` is not a single, 4 digit number (either character or numeric). Previously, the function would continue and throw confusing error messages

Old
```
> load_variables(year = c(2005, 2006), 'acs1')
Error in parse_url(url) : length(url) == 1 is not TRUE
In addition: Warning message:
In if (year == 1990) { :
  the condition has length > 1 and only the first element will be used
```

New
```
> load_variables(year = c(2005, 2006), 'acs1')
Error in load_variables(year = c(2005, 2006), "acs1") : 
  Argument "year" must be a single year in format YYYY.
```

Old
```
> load_variables(year = "06", 'acs1')
Error: 1-year ACS support in tidycensus begins with the 2005 1-year ACS. Consider using decennial Census data instead.
```

New
```
> load_variables(year = "06", 'acs1')
Error in load_variables(year = 6, "acs1") : 
  Argument "year" must be a single year in format YYYY.
```

### Checking Dataset

Any invalid dataset will now trigger an error listing valid/currently-implemented datasets (per the suggestion in https://github.com/walkerke/tidycensus/issues/419 by @mikemahoney218).

Old
```
> load_variables(year = 2005, 'acs')
Error: lexical error: invalid char in json text.
                                       <html><head><title>Error report
                     (right here) ------^
```

New
```
> load_variables(year = 2005, 'acs')
Error in load_variables(year = 2005, "acs") : 
  Argument "dataset" must be one (and only one) of: 
sf1, sf2, sf3, sf4, pl, as, gu, mp, vi, acs1, acs3, acs5, acs1/profile, acs3/profile, acs5/profile, acs1/subject, acs3/subject, acs5/subject
```

### Check Status Code of API Response

Previously, if the user requested a non-existent dataset that wasn’t caught by checks in the function, the 404 response from the API was parsed as if it were a valid response, throwing a confusing error message. `load_variables` will now check the response from the API, directing the user to the API’s data webpage if the dataset doesn’t exist (404) or repeating the server’s error in case of any other non-successful status. 

Old 
```
> load_variables(year = 1996, 'sf1')
Error: lexical error: invalid char in json text.
                                       <html><head><title>Error report
                     (right here) ------^
```

New
```
> load_variables(year = 1996, 'sf1')
 Error in get_dataset(dataset, year) : 
  API endpoint not found. Does this data set exist for the specified year? See https://api.census.gov/data.html for data availability. 
```
