### PR TITLE
Throw errorin interpolate_pw() if inputs have different CRS and CRS not supplied

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -389,11 +389,16 @@ interpolate_pw <- function(from,
          call. = FALSE)
   }
 
-  # If CRS is given, transform all the objects
+  # If CRS is given, transform all the objects; error if mismatched CRS
   if (!is.null(crs)) {
     from <- sf::st_transform(from, crs)
     to <- sf::st_transform(to, crs)
     weights <- sf::st_transform(weights, crs)
+  } else {
+    unique_crs <- unique(c(sf::st_crs(from), sf::st_crs(to), sf::st_crs(weights)))
+    if (length(unique_crs) != 1) {
+      stop("All inputs must have the same CRS if CRS is not supplied")
+    }
   }
 
   # Make a from and a to ID


### PR DESCRIPTION
Check to see if `from`, `to`, and `weights` have the same CRS if CRS is not supplied as a function argument to `interpolate_pw()`. This saves time if `weights` is large and a long time is spent generating centroids before `sf::st_join()` will inevitably fail when trying to create `denomiators` due to the mismatched CRS.