### PR TITLE
Add the ability to filter ZCTA results by state in get_acs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     utils,
     rlang,
     crayon,
-    tidyselect
+    tidyselect,
+    zctaCrosswalk
 Suggests: 
     ggplot2,
     survey,

--- a/R/acs.R
+++ b/R/acs.R
@@ -683,8 +683,10 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
   } else {
     vars <- format_variables_acs(variables)
 
-    dat <- suppressWarnings(load_data_acs(geography, vars, key, year, state, county,
-                                          zcta, survey, show_call = show_call))
+
+      dat <- suppressWarnings(load_data_acs(geography, vars, key, year, state, county,
+                                            zcta, survey, show_call = show_call))
+
   }
 
   vars2 <- format_variables_acs(variables)
@@ -739,6 +741,12 @@ get_acs <- function(geography, variables = NULL, table = NULL, cache_table = FAL
 
     dat <- dat[!duplicated(names(dat), fromLast = TRUE)]
     dat <- dat[c("GEOID", "NAME", var_vector)]
+
+    }
+
+  # Filters zctas within state queried
+  if(!is.na(state) & geography == "zip code tabulation area"){
+    dat <- dat[dat$GEOID %in% zctaCrosswalk::zcta_crosswalk[zctaCrosswalk::zcta_crosswalk$state_usps == state,]$zcta,]
 
 
     # Convert missing values to NA

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -157,10 +157,6 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
 
   if (!is.null(zcta))  {
 
-    # if (is.null(state)) {
-    #   stop("The `zcta` argument requires specifying a state.", call. = FALSE)
-    # }
-
     if (!is.null(county)) {
       stop("ZCTAs do not nest within counties, so `county` should not be specified.",
            call. = FALSE)
@@ -172,6 +168,10 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
       })
 
       in_area <- paste0("state:", state)
+
+      if(geography == "zip code tabulation area"){
+        in_area <- NULL
+      }
 
     } else {
       in_area <- NULL
@@ -231,6 +231,11 @@ load_data_acs <- function(geography, formatted_variables, key, year, state = NUL
         in_area <- paste0("state:", state)
       }
 
+    }
+
+    # If state is supplied for zctas, query all and filter after in get_acs
+    if(geography == "zip code tabulation area"){
+      in_area <- NULL
     }
 
     vars_to_get <- paste0(formatted_variables, ",NAME")


### PR DESCRIPTION
I encountered this issue trying to pull data specific to my state. In this PR I have:

- added a check in load_data_acs to query all ZCTAs if the state argument is supplied
- added a statement in acs.R to filter returned results by the state argument when these conditions are met
- added the dependency for zctaCrosswalk to quickly filter results