### PR TITLE
Add `.data$` prefix

### DIFF
--- a/R/flows.R
+++ b/R/flows.R
@@ -239,7 +239,7 @@ get_flows <- function(geography, variables = NULL, breakdown = NULL,
       # join back to original data and drop id col
       dat <- to_recode %>%
         dplyr::left_join(recoded_wide, by = "id") %>%
-        dplyr::select(-id)
+        dplyr::select(-.data$id)
 
     # # we need to know all the possible vars NOT to pivot if ouput = tidy in next steop
     # all_breakdown_vars <- c(all_breakdown_vars, breakdown_ordered)


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package does one of two things:

- It re-exports `dplyr::id()`, which has been defunct for many years and has now been removed from dplyr.

- It references a column named `id`, likely in a `mutate()` or `summarise()`, but does not note this as a global variable with `utils::globalVariables("id")`. In this case, you got lucky that dplyr exported `id()`, meaning that you did not need a global variable for `"id"`. Since we have removed `dplyr::id()`, your package will need this now.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!