### PR TITLE
Derive PUMS `recode_years`  from `pums_variables` (remove hard-coding)

### DIFF
--- a/R/load_data.R
+++ b/R/load_data.R
@@ -735,12 +735,18 @@ load_data_estimates <- function(geography, product = NULL, variables = NULL, key
   return(dat)
 }
 
+get_pums_recode_years <- function(survey) {
+  yrs <- tidycensus::pums_variables$year[tidycensus::pums_variables$survey == survey]
+  sort(unique(as.integer(yrs)))
+}
+
+
 load_data_pums <- function(variables, state, puma, key, year, survey,
                            variables_filter, recode, show_call) {
 
   # for which years is data dictionary available in pums_variables?
   # we'll use this a couple times later on
-  recode_years <- 2017:2023
+  recode_years <- get_pums_recode_years(survey)
 
   base <- sprintf("https://api.census.gov/data/%s/acs/%s/pums",
                   year, survey)
@@ -1026,7 +1032,7 @@ load_data_pums_vacant <- function(variables, state, puma, key, year, survey,
 
   # for which years is data dictionary available in pums_variables?
   # we'll use this a couple times later on
-  recode_years <- 2017:2023
+  recode_years <- get_pums_recode_years(survey)
 
   base <- sprintf("https://api.census.gov/data/%s/acs/%s/pums",
                   year, survey)


### PR DESCRIPTION
### What this does
Closes #634 

`load_data.R` currently hard-codes the year range used to determine whether PUMS recoding is supported (via `recode_years <- ...`). This PR derives the supported years directly from the packaged `pums_variables` dataset (scoped to the requested `survey`), so adding new PUMS dictionaries doesn’t require updating code in `load_data.R`.

No intended behavior changes beyond removing the manual maintenance step.

### Why

`pums_variables` already contains the authoritative list of `survey`/`year` combinations with dictionaries (and thus recode support). Using it eliminates the need to update `recode_years` annually.

### Tests I ran

* **2023 `acs1` recode works (labels returned):**

```r
get_pums(state = "Vermont", variables = c("AGEP","SEX"), year = 2023, survey = "acs1", recode = TRUE)
```

Result includes `STATE_label` and `SEX_label` columns.

* **2024 `acs1` currently does *not* recode on main (expected until dictionary update):**

```r
get_pums(state = "Vermont", variables = c("AGEP","SEX"), year = 2024, survey = "acs1", recode = TRUE)
```

Result shows the current message:

> Recoding is currently supported for 2017 - 2023 data. Returning original data only.

(With this PR, the supported-year check is no longer hard-coded and will automatically reflect the years present in `pums_variables` once 2024 is added.)

### Notes

* This PR only changes how supported recode years are determined; it does **not** add or modify any PUMS dictionaries/data objects.
* Companion PR #635 adds 2024 `acs1` dictionary support.