### PR TITLE
Fix load_variables - new requirement for census key

### DIFF
--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -25,6 +25,7 @@
 #' @param dataset The dataset name as used on the Census website.  See the Details in this documentation for a full list of dataset names.
 #' @param cache Whether you would like to cache the dataset for future access,
 #'   or load the dataset from an existing cache. Defaults to FALSE.
+#' @param key a Census API key
 #'
 #' @return A tibble of variables from the requested dataset.
 #' @examples \dontrun{
@@ -48,6 +49,7 @@ load_variables <- function(
               "slds", "sldhprofile", "sldsprofile", "cqr",
               "cd113", "cd113profile", "cd115", "cd115profile", "cd116",
               "plnat", "cd118"),
+  key = NULL,
   cache = FALSE) {
 
   if (length(year) != 1 || !grepl('[0-9]{4}', year)){
@@ -119,9 +121,9 @@ load_variables <- function(
 
     set <- paste(year, d, sep = "/")
     key <- get_census_api_key(key)
-    url <- paste("https://api.census.gov/data",
+    url <- paste0(paste("https://api.census.gov/data",
                  set,
-                 "variables.json?key=",key, sep = "/")
+                 "variables.json", sep = "/"), "?key=", key)
     resp <- httr::GET(url)
     if(httr::status_code(resp) == 404L){
       stop("API endpoint not found. Does this data set exist for the specified year? See https://api.census.gov/data.html for data availability.")

--- a/R/search_variables.R
+++ b/R/search_variables.R
@@ -118,10 +118,10 @@ load_variables <- function(
   get_dataset <- function(d, year) {
 
     set <- paste(year, d, sep = "/")
-
+    key <- get_census_api_key(key)
     url <- paste("https://api.census.gov/data",
                  set,
-                 "variables.json", sep = "/")
+                 "variables.json?key=",key, sep = "/")
     resp <- httr::GET(url)
     if(httr::status_code(resp) == 404L){
       stop("API endpoint not found. Does this data set exist for the specified year? See https://api.census.gov/data.html for data availability.")

--- a/man/load_variables.Rd
+++ b/man/load_variables.Rd
@@ -12,9 +12,9 @@ load_variables(
     "acs5/profile", "acs1/subject", "acs3/subject", "acs5/subject", "acs1/cprofile",
     "acs5/cprofile", "sf2profile", "sf3profile", "sf4profile", "aian", "aianprofile",
     "cd110h", "cd110s", "cd110hprofile", "cd110sprofile", "sldh", "slds", "sldhprofile",
-    "sldsprofile", "cqr", 
-     "cd113", "cd113profile", "cd115", "cd115profile",
-    "cd116", "plnat", "cd118"),
+    "sldsprofile", "cqr",      "cd113", "cd113profile", "cd115", "cd115profile", "cd116",
+    "plnat", "cd118"),
+  key = NULL,
   cache = FALSE
 )
 }
@@ -25,6 +25,8 @@ available from 2009 through 2020. 1-year ACS data is available from 2005
 through 2021, with the exception of 2020.}
 
 \item{dataset}{The dataset name as used on the Census website.  See the Details in this documentation for a full list of dataset names.}
+
+\item{key}{a Census API key}
 
 \item{cache}{Whether you would like to cache the dataset for future access,
 or load the dataset from an existing cache. Defaults to FALSE.}

--- a/man/tidycensus-package.Rd
+++ b/man/tidycensus-package.Rd
@@ -6,7 +6,7 @@
 \alias{tidycensus-package}
 \title{tidycensus: Load US Census Boundary and Attribute Data as 'tidyverse' and 'sf'-Ready Data Frames}
 \description{
-An integrated R interface to several United States Census Bureau APIs (\url{https://www.census.gov/data/developers/data-sets.html}) and the US Census Bureau's geographic boundary files. Allows R users to return Census and ACS data as tidyverse-ready data frames, and optionally returns a list-column with feature geometry for mapping and spatial analysis.
+An integrated R interface to several United States Census Bureau APIs (<https://www.census.gov/data/developers/data-sets.html>) and the US Census Bureau's geographic boundary files. Allows R users to return Census and ACS data as tidyverse-ready data frames, and optionally returns a list-column with feature geometry for mapping and spatial analysis.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
Add a key argument to load_variables, and provide to url to comply with 2026-05-12 policy requiring an API key for all requests. 