### PR TITLE
Fix 2010 ZCTA geometries for get_decennial()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tidycensus
 Type: Package
 Title: Load US Census Boundary and Attribute Data as 'tidyverse' and 'sf'-Ready Data Frames
-Version: 1.8.1
+Version: 1.8.2
 Authors@R: c(
     person(given = "Kyle", family = "Walker", email="kyle@walker-data.com", role=c("aut", "cre")),
     person(given = "Matt", family = "Herman", email = "mfherman@gmail.com", role = "aut"),

--- a/R/census.R
+++ b/R/census.R
@@ -441,8 +441,8 @@ get_decennial <- function(geography,
   }
 
   # For ZCTAs, strip the state code from GEOID (issue #338 and #358)
-  # Should only happen if the GEOID is 7 characters
-  if (stringr::str_detect(geography, "^zip code tabulation area") && unique(nchar(dat2$GEOID)) == 7) {
+  # Should only happen if any GEOID is 7 characters
+  if (stringr::str_detect(geography, "^zip code tabulation area") && any(nchar(dat2$GEOID) == 7L)) {
     dat2 <- dat2 %>%
       dplyr::mutate(
         GEOID = stringr::str_sub(GEOID, start = -5L)
@@ -459,10 +459,10 @@ get_decennial <- function(geography,
                                                          sumfile = "sf3", pop_group, state, county, show_call = show_call)))
     }
 
-    if (geography == "zip code tabulation area (or part)" && year == 2020 && unique(nchar(dat2$GEOID)) == 7) {
+    if (geography == "zip code tabulation area (or part)" && year == 2020 && any(nchar(dat2$GEOID) == 7L)) {
       dat2 <- dat2 %>%
         dplyr::mutate(
-          GEOID = stringr::str_sub(GEOID, start = 3L)
+          GEOID = stringr::str_sub(GEOID, start = -5L)
         )
     }
 
@@ -513,6 +513,12 @@ get_decennial <- function(geography,
 
       if ("try-error" %in% class(geom)) {
         stop("Your geometry data download failed. Please try again later or check the status of the Census Bureau website at https://www2.census.gov/geo/tiger/", call. = FALSE)
+      }
+
+      # For ZCTAs, strip the state code from GEOID
+      # Should only happen if any GEOID is 7 characters
+      if (stringr::str_detect(geography, "^zip code tabulation area") && any(nchar(geom$GEOID) == 7L)) {
+        geom$GEOID <- stringr::str_sub(geom$GEOID, start = -5L)
       }
     }
 

--- a/R/census.R
+++ b/R/census.R
@@ -462,7 +462,7 @@ get_decennial <- function(geography,
     if (geography == "zip code tabulation area (or part)" && year == 2020 && any(nchar(dat2$GEOID) == 7L)) {
       dat2 <- dat2 %>%
         dplyr::mutate(
-          GEOID = stringr::str_sub(GEOID, start = -5L)
+          GEOID = stringr::str_sub(GEOID, start = 3L)
         )
     }
 

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -34,18 +34,50 @@ test_that("get_decennial normalizes state-prefixed ZCTA GEOIDs", {
     }
   )
 
+  ##############################################################################
+  # Year 2000
+
+  # Anticipate the warning for year-2000 ZCTAs including separate polygons
+  expect_warning(
+    out <- suppressMessages(
+      get_decennial(
+        geography = "zcta",
+        variables = "P010001",
+        year = 2000,
+        state = "WY",
+        key = "test-key",
+        output = "wide",
+        geometry = TRUE
+      )
+    ),
+    regexp = "ZCTAs for 2000 include separate polygons for discontiguous parts"
+  )
+
+  # Ensure GEOIDs for ZCTAs got the two-digit state prefix removed
+  expect_equal(out$GEOID, c("82001", "82007"))
+
+  # Geometry column has data
+  expect_all_false(sf::st_is_empty(out))
+
+  ##############################################################################
+  # Year 2010
   out <- suppressMessages(
     get_decennial(
       geography = "zcta",
       variables = "P010001",
-      year = 2000,
+      year = 2010,
       state = "WY",
       key = "test-key",
-      output = "wide"
+      output = "wide",
+      geometry = TRUE
     )
   )
 
+  # Ensure GEOIDs for ZCTAs got the two-digit state prefix removed
   expect_equal(out$GEOID, c("82001", "82007"))
+
+  # Geometry column has data
+  expect_all_false(sf::st_is_empty(out))
 })
 
 test_that("variables_from_table_acs drops comparison profile significance columns", {


### PR DESCRIPTION
The `geometry` column was empty for `get_decennial(geography = "ZCTA", year = 2010, geometry = TRUE)`.

Despite the fact that tidycensus stripped the state prefix from ZCTA GEOIDs, `tigris::zctas(year = 2010)` includes the prefix as well. As a result, the `right_join()` was not successfully joining the tidycensus numbers with the geometries. 

This PR adds code to strip the state prefix from the tigris output. It also adds tests.

Additionally, I changed `unique()` to `any()` in the `if` statements, because theoretically `unique()` could yield a vector of more than one element and break the `if` statement, causing a confusing error message difficult to debug.